### PR TITLE
Add handle::event

### DIFF
--- a/src/phantasm-renderer/backend/Backend.hh
+++ b/src/phantasm-renderer/backend/Backend.hh
@@ -133,13 +133,26 @@ public:
     //
 
     /// create a command list handle from a software command buffer
-    [[nodiscard]] virtual handle::command_list recordCommandList(std::byte* buffer, size_t size) = 0;
+    /// event_to_set: optional, will be set once the command list has finished executing (on the GPU, after submission)
+    [[nodiscard]] virtual handle::command_list recordCommandList(std::byte* buffer, size_t size, handle::event event_to_set = handle::null_event) = 0;
 
     /// destroy the given command list handles
     virtual void discard(cc::span<handle::command_list const> cls) = 0;
 
     /// submit and destroy the given command list handles
     virtual void submit(cc::span<handle::command_list const> cls) = 0;
+
+    //
+    // Event interface
+    //
+
+    /// create an event, starts out unset
+    [[nodiscard]] virtual handle::event createEvent() = 0;
+
+    /// if the event is set, unsets it and returns true, otherwise returns false
+    [[nodiscard]] virtual bool tryUnsetEvent(handle::event event) = 0;
+
+    virtual void free(cc::span<handle::event const> events) = 0;
 
     //
     // Raytracing interface

--- a/src/phantasm-renderer/backend/commands.hh
+++ b/src/phantasm-renderer/backend/commands.hh
@@ -51,8 +51,8 @@ enum class cmd_queue_type : uint8_t
 
 struct cmd_base
 {
-    cmd_type type;
-    cmd_base(cmd_type t) : type(t) {}
+    cmd_type s_internal_type;
+    cmd_base(cmd_type t) : s_internal_type(t) {}
 };
 
 template <cmd_type TYPE, cmd_queue_type QUEUE = cmd_queue_type::graphics>
@@ -450,7 +450,7 @@ PR_CMD_TYPE_VALUES
 template <class F>
 void dynamic_dispatch(detail::cmd_base const& base, F& callback)
 {
-    switch (base.type)
+    switch (base.s_internal_type)
     {
 #define PR_X(_val_)                                                            \
     case detail::cmd_type::_val_:                                              \
@@ -494,7 +494,7 @@ public:
 
         iterator& operator++()
         {
-            auto const advance = cmd::detail::get_command_size(_pos->type);
+            auto const advance = cmd::detail::get_command_size(_pos->s_internal_type);
             _pos = reinterpret_cast<cmd::detail::cmd_base*>(reinterpret_cast<std::byte*>(_pos) + advance);
             _remaining_size -= advance;
             return *this;

--- a/src/phantasm-renderer/backend/config.hh
+++ b/src/phantasm-renderer/backend/config.hh
@@ -84,6 +84,7 @@ struct backend_config
     unsigned max_num_srvs = 2048;
     unsigned max_num_uavs = 2048;
     unsigned max_num_samplers = 1024;
+    unsigned max_num_events = 4096;
     unsigned max_num_accel_structs = 2048;
     unsigned max_num_raytrace_pipeline_states = 256;
 

--- a/src/phantasm-renderer/backend/d3d12/BackendD3D12.cc
+++ b/src/phantasm-renderer/backend/d3d12/BackendD3D12.cc
@@ -66,13 +66,13 @@ void pr::backend::d3d12::BackendD3D12::initialize(const pr::backend::backend_con
     {
         mPoolResources.initialize(device, config.max_num_resources);
         mPoolShaderViews.initialize(&device, &mPoolResources, config.max_num_cbvs, config.max_num_srvs + config.max_num_uavs, config.max_num_samplers);
-        mPoolPSOs.initialize(&device, mDevice.getDeviceRaytracing(), config.max_num_pipeline_states, config.max_num_raytrace_pipeline_states);
+        mPoolPSOs.initialize(&device, mDevice.getDevice5(), config.max_num_pipeline_states, config.max_num_raytrace_pipeline_states);
         mPoolEvents.initialize(&device, config.max_num_events);
 
         if (isRaytracingEnabled())
         {
-            mPoolAccelStructs.initialize(mDevice.getDeviceRaytracing(), &mPoolResources, config.max_num_accel_structs);
-            mShaderTableCtor.initialize(mDevice.getDeviceRaytracing(), &mPoolShaderViews, &mPoolResources, &mPoolPSOs, &mPoolAccelStructs);
+            mPoolAccelStructs.initialize(mDevice.getDevice5(), &mPoolResources, config.max_num_accel_structs);
+            mShaderTableCtor.initialize(mDevice.getDevice5(), &mPoolShaderViews, &mPoolResources, &mPoolPSOs, &mPoolAccelStructs);
         }
     }
 

--- a/src/phantasm-renderer/backend/d3d12/BackendD3D12.cc
+++ b/src/phantasm-renderer/backend/d3d12/BackendD3D12.cc
@@ -67,7 +67,7 @@ void pr::backend::d3d12::BackendD3D12::initialize(const pr::backend::backend_con
         mPoolResources.initialize(device, config.max_num_resources);
         mPoolShaderViews.initialize(&device, &mPoolResources, config.max_num_cbvs, config.max_num_srvs + config.max_num_uavs, config.max_num_samplers);
         mPoolPSOs.initialize(&device, mDevice.getDeviceRaytracing(), config.max_num_pipeline_states, config.max_num_raytrace_pipeline_states);
-
+        mPoolEvents.initialize(&device, config.max_num_events);
 
         if (isRaytracingEnabled())
         {
@@ -108,6 +108,8 @@ void pr::backend::d3d12::BackendD3D12::destroy()
 
         mPoolCmdLists.destroy();
         mPoolAccelStructs.destroy();
+
+        mPoolEvents.destroy();
         mPoolPSOs.destroy();
         mPoolShaderViews.destroy();
         mPoolResources.destroy();
@@ -152,12 +154,14 @@ void pr::backend::d3d12::BackendD3D12::onResize(tg::isize2 size)
 
 pr::backend::format pr::backend::d3d12::BackendD3D12::getBackbufferFormat() const { return util::to_pr_format(mSwapchain.getBackbufferFormat()); }
 
-pr::backend::handle::command_list pr::backend::d3d12::BackendD3D12::recordCommandList(std::byte* buffer, size_t size)
+pr::backend::handle::command_list pr::backend::d3d12::BackendD3D12::recordCommandList(std::byte* buffer, size_t size, handle::event event_to_set)
 {
     auto& thread_comp = mThreadComponents[mThreadAssociation.get_current_index()];
 
+    ID3D12Fence* const raw_fence_to_set = event_to_set.is_valid() ? mPoolEvents.get(event_to_set) : nullptr;
+
     ID3D12GraphicsCommandList* raw_list;
-    auto const res = mPoolCmdLists.create(raw_list, thread_comp.cmd_list_allocator);
+    auto const res = mPoolCmdLists.create(raw_list, thread_comp.cmd_list_allocator, raw_fence_to_set);
     thread_comp.translator.translateCommandList(raw_list, mPoolCmdLists.getStateCache(res), buffer, size);
     return res;
 }
@@ -225,6 +229,25 @@ void pr::backend::d3d12::BackendD3D12::submit(cc::span<const pr::backend::handle
 
     if (num_cls_in_batch > 0)
         submit_flush();
+}
+
+bool pr::backend::d3d12::BackendD3D12::tryUnsetEvent(pr::backend::handle::event event)
+{
+    auto* const raw_fence = mPoolEvents.get(event);
+
+    auto const completed_val = raw_fence->GetCompletedValue();
+    if (completed_val == 1)
+    {
+        // "signalled", reset to 0
+        raw_fence->Signal(0);
+        return true;
+    }
+    else
+    {
+        // these fences should only ever be 0 or 1
+        CC_ASSERT(completed_val == 0 && "unexpected fence value in handle::event check");
+        return false;
+    }
 }
 
 pr::backend::handle::pipeline_state pr::backend::d3d12::BackendD3D12::createRaytracingPipelineState(arg::raytracing_shader_libraries libraries,

--- a/src/phantasm-renderer/backend/d3d12/Device.cc
+++ b/src/phantasm-renderer/backend/d3d12/Device.cc
@@ -1,5 +1,6 @@
 #include "Device.hh"
 
+#include "adapter_choice_util.hh"
 #include "common/d3d12_sanitized.hh"
 #include "common/log.hh"
 #include "common/verify.hh"
@@ -25,31 +26,8 @@ void pr::backend::d3d12::Device::initialize(IDXGIAdapter& adapter, const backend
     PR_D3D12_VERIFY(::D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_12_0, PR_COM_WRITE(mDevice)));
 
     // Capability checks
+    mFeatures = check_capabilities(mDevice);
 
-    // SM 6.0
-    {
-        D3D12_FEATURE_DATA_SHADER_MODEL feat_data = {D3D_SHADER_MODEL_6_0};
-        auto const success = SUCCEEDED(mDevice->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &feat_data, sizeof(feat_data)));
-        mCapabilities.sm6 = success && feat_data.HighestShaderModel >= D3D_SHADER_MODEL_6_0;
-    }
-
-    // SM 6.0 wave intrinsics
-    if (mCapabilities.sm6)
-    {
-        D3D12_FEATURE_DATA_D3D12_OPTIONS1 feat_data = {};
-        auto const success = SUCCEEDED(mDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &feat_data, sizeof(feat_data)));
-        mCapabilities.sm6_wave_intrins = success && feat_data.WaveOps;
-    }
-
-    // DXR raytracing support and device query
-    if (config.enable_raytracing)
-    {
-        D3D12_FEATURE_DATA_D3D12_OPTIONS5 feat_data = {};
-        auto const success = SUCCEEDED(mDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS5, &feat_data, sizeof(feat_data)));
-        if (success && feat_data.RaytracingTier != D3D12_RAYTRACING_TIER_NOT_SUPPORTED)
-        {
-            auto const query_success = SUCCEEDED(mDevice->QueryInterface(PR_COM_WRITE(mDeviceRaytracing)));
-            mCapabilities.raytracing = query_success && mDeviceRaytracing.is_valid();
-        }
-    }
+    // QIs
+    auto const got_device5 = SUCCEEDED(mDevice->QueryInterface(PR_COM_WRITE(mDevice5)));
 }

--- a/src/phantasm-renderer/backend/d3d12/Device.hh
+++ b/src/phantasm-renderer/backend/d3d12/Device.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <phantasm-renderer/backend/config.hh>
+#include <phantasm-renderer/backend/gpu_info.hh>
 
 #include "common/d3d12_fwd.hh"
 #include "common/shared_com_ptr.hh"
@@ -9,7 +10,6 @@ namespace pr::backend::d3d12
 {
 class Device
 {
-    // reference type
 public:
     Device() = default;
     Device(Device const&) = delete;
@@ -19,26 +19,21 @@ public:
 
     void initialize(IDXGIAdapter& adapter, backend_config const& config);
 
-    bool hasSM6() const { return mCapabilities.sm6; }
-    bool hasSM6WaveIntrinsics() const { return mCapabilities.sm6_wave_intrins; }
-    bool hasRaytracing() const { return mCapabilities.raytracing; }
+    gpu_feature_flags getFeatures() const { return mFeatures; }
+    bool hasSM6WaveIntrinsics() const { return mFeatures.has(gpu_feature::hlsl_wave_ops); }
+    bool hasRaytracing() const { return mFeatures.has(gpu_feature::raytracing); }
+    bool hasVariableRateShading() const { return mFeatures.has_any_of({gpu_feature::shading_rate_t1, gpu_feature::shading_rate_t2}); }
 
     ID3D12Device& getDevice() const { return *mDevice.get(); }
     shared_com_ptr<ID3D12Device> const& getDeviceShared() const { return mDevice; }
 
-    ID3D12Device5* getDeviceRaytracing() const { return mDeviceRaytracing.get(); }
+    ID3D12Device5* getDevice5() const { return mDevice5.get(); }
 
 private:
     shared_com_ptr<ID3D12DeviceRemovedExtendedDataSettings> mDREDSettings;
     shared_com_ptr<ID3D12Device> mDevice;
-    shared_com_ptr<ID3D12Device5> mDeviceRaytracing;
-
-    struct capabilities
-    {
-        bool sm6 = false;
-        bool sm6_wave_intrins = false;
-        bool raytracing = false;
-    } mCapabilities;
+    shared_com_ptr<ID3D12Device5> mDevice5;
+    gpu_feature_flags mFeatures;
 };
 
 }

--- a/src/phantasm-renderer/backend/d3d12/adapter_choice_util.hh
+++ b/src/phantasm-renderer/backend/d3d12/adapter_choice_util.hh
@@ -9,6 +9,8 @@
 
 namespace pr::backend::d3d12
 {
+[[nodiscard]] gpu_feature_flags check_capabilities(ID3D12Device* device);
+
 /// Test the given adapter by creating a device with the min_feature level, returns the amount of device nodes, >= 0 on success
 [[nodiscard]] int test_adapter(IDXGIAdapter* adapter, D3D_FEATURE_LEVEL min_features, D3D_FEATURE_LEVEL& out_max_features);
 

--- a/src/phantasm-renderer/backend/d3d12/pools/accel_struct_pool.cc
+++ b/src/phantasm-renderer/backend/d3d12/pools/accel_struct_pool.cc
@@ -19,7 +19,7 @@ pr::backend::handle::accel_struct pr::backend::d3d12::AccelStructPool::createBot
 
     new_node.geometries.reserve(elements.size());
 
-    // build the VkGeometryNVs from the vertex/index buffer pairs
+    // build the D3D12_RAYTRACING_GEOMETRY_DESCs from the vertex/index buffer pairs
     for (auto const& elem : elements)
     {
         auto const& vert_info = mResourcePool->getBufferInfo(elem.vertex_buffer);
@@ -163,7 +163,7 @@ void pr::backend::d3d12::AccelStructPool::destroy()
 
         if (num_leaks > 0)
         {
-            log::info()("warning: leaked %d handle::accel_struct object%s", num_leaks, num_leaks == 1 ? "" : "s");
+            log::info()("warning: leaked {} handle::accel_struct object{}", num_leaks, num_leaks == 1 ? "" : "s");
         }
     }
 }
@@ -186,16 +186,8 @@ pr::backend::d3d12::AccelStructPool::accel_struct_node& pr::backend::d3d12::Acce
     return mPool.get(res);
 }
 
-void pr::backend::d3d12::AccelStructPool::moveGeometriesToAS(pr::backend::handle::accel_struct as)
-{
-    CC_ASSERT(as.is_valid());
-    //    mPool.get(static_cast<unsigned>(as.index)).geometries = cc::move(geometries);
-}
-
 void pr::backend::d3d12::AccelStructPool::internalFree(pr::backend::d3d12::AccelStructPool::accel_struct_node& node)
 {
-    //    vkDestroyAccelerationStructureNV(mDevice, node.raw_as, nullptr);
-
     cc::array const buffers_to_free = {node.buffer_as, node.buffer_scratch, node.buffer_instances};
     mResourcePool->free(buffers_to_free);
 }

--- a/src/phantasm-renderer/backend/d3d12/pools/accel_struct_pool.hh
+++ b/src/phantasm-renderer/backend/d3d12/pools/accel_struct_pool.hh
@@ -64,8 +64,6 @@ public:
 private:
     accel_struct_node& acquireAccelStruct(handle::accel_struct& out_handle);
 
-    void moveGeometriesToAS(handle::accel_struct as /*, cc::vector<VkGeometryNV>&& geometries*/);
-
     void internalFree(accel_struct_node& node);
 
 private:

--- a/src/phantasm-renderer/backend/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-renderer/backend/d3d12/pools/cmd_list_pool.cc
@@ -115,7 +115,9 @@ bool pr::backend::d3d12::cmd_allocator_node::is_submit_counter_up_to_date() cons
     return (submits_since_reset == possible_submits_remaining);
 }
 
-pr::backend::handle::command_list pr::backend::d3d12::CommandListPool::create(ID3D12GraphicsCommandList*& out_cmdlist, CommandAllocatorBundle& thread_allocator)
+pr::backend::handle::command_list pr::backend::d3d12::CommandListPool::create(ID3D12GraphicsCommandList*& out_cmdlist,
+                                                                              CommandAllocatorBundle& thread_allocator,
+                                                                              ID3D12Fence* fence_to_set)
 {
     unsigned res_handle;
     {
@@ -127,6 +129,7 @@ pr::backend::handle::command_list pr::backend::d3d12::CommandListPool::create(ID
 
     cmd_list_node& new_node = mPool.get(res_handle);
     new_node.responsible_allocator = thread_allocator.acquireMemory(out_cmdlist);
+    new_node.fence_to_set = fence_to_set;
 
     return {static_cast<handle::index_t>(res_handle)};
 }

--- a/src/phantasm-renderer/backend/d3d12/pools/event_pool.cc
+++ b/src/phantasm-renderer/backend/d3d12/pools/event_pool.cc
@@ -1,0 +1,70 @@
+#include "event_pool.hh"
+
+#include <phantasm-renderer/backend/d3d12/common/d3d12_sanitized.hh>
+#include <phantasm-renderer/backend/d3d12/common/log.hh>
+#include <phantasm-renderer/backend/d3d12/common/verify.hh>
+
+pr::backend::handle::event pr::backend::d3d12::EventPool::createEvent()
+{
+    unsigned pool_index;
+    {
+        auto lg = std::lock_guard(mMutex);
+        pool_index = mPool.acquire();
+    }
+
+    ID3D12Fence*& new_fence = mPool.get(pool_index);
+    mDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&new_fence));
+
+    return {static_cast<handle::index_t>(pool_index)};
+}
+
+void pr::backend::d3d12::EventPool::free(pr::backend::handle::event event)
+{
+    if (!event.is_valid())
+        return;
+
+    mPool.get(static_cast<unsigned>(event.index))->Release();
+
+    {
+        auto lg = std::lock_guard(mMutex);
+        mPool.release(static_cast<unsigned>(event.index));
+    }
+}
+
+void pr::backend::d3d12::EventPool::free(cc::span<const pr::backend::handle::event> event_span)
+{
+    auto lg = std::lock_guard(mMutex);
+
+    for (auto as : event_span)
+    {
+        if (as.is_valid())
+        {
+            mPool.get(static_cast<unsigned>(as.index))->Release();
+            mPool.release(static_cast<unsigned>(as.index));
+        }
+    }
+}
+
+void pr::backend::d3d12::EventPool::initialize(ID3D12Device* device, unsigned max_num_events)
+{
+    CC_ASSERT(mDevice == nullptr && "double init");
+    mDevice = device;
+    mPool.initialize(max_num_events);
+}
+
+void pr::backend::d3d12::EventPool::destroy()
+{
+    if (mDevice != nullptr)
+    {
+        auto num_leaks = 0;
+        mPool.iterate_allocated_nodes([&](ID3D12Fence* leaked_event, unsigned) {
+            ++num_leaks;
+            leaked_event->Release();
+        });
+
+        if (num_leaks > 0)
+        {
+            log::info()("warning: leaked {} handle::event object{}", num_leaks, num_leaks == 1 ? "" : "s");
+        }
+    }
+}

--- a/src/phantasm-renderer/backend/d3d12/pools/event_pool.hh
+++ b/src/phantasm-renderer/backend/d3d12/pools/event_pool.hh
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <mutex>
+
+#include <phantasm-renderer/backend/detail/linked_pool.hh>
+#include <phantasm-renderer/backend/types.hh>
+
+#include <phantasm-renderer/backend/d3d12/common/d3d12_fwd.hh>
+
+namespace pr::backend::d3d12
+{
+class EventPool
+{
+public:
+    [[nodiscard]] handle::event createEvent();
+
+    void free(handle::event event);
+    void free(cc::span<handle::event const> event_span);
+
+public:
+    void initialize(ID3D12Device* device, unsigned max_num_events);
+    void destroy();
+
+    ID3D12Fence* get(handle::event event) const
+    {
+        CC_ASSERT(event.is_valid() && "invalid handle::event");
+        return mPool.get(static_cast<unsigned>(event.index));
+    }
+
+private:
+    ID3D12Device* mDevice = nullptr;
+
+    backend::detail::linked_pool<ID3D12Fence*, unsigned> mPool;
+
+    std::mutex mMutex;
+};
+
+}

--- a/src/phantasm-renderer/backend/gpu_info.hh
+++ b/src/phantasm-renderer/backend/gpu_info.hh
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include <clean-core/flags.hh>
 #include <clean-core/span.hh>
 #include <clean-core/string.hh>
 
@@ -27,15 +28,20 @@ enum class gpu_capabilities : uint8_t
     insufficient,
     level_1,
     level_2,
-    level_3,
-    level_4,
-    level_5,
-    level_6,
-    level_7,
-    level_8,
-    level_9,
-    level_10
+    level_3
 };
+
+// explicit GPU features
+enum class gpu_feature : uint8_t
+{
+    raytracing,
+    shading_rate_t1,
+    shading_rate_t2,
+    hlsl_sm6,
+    hlsl_wave_ops
+};
+
+using gpu_feature_flags = cc::flags<gpu_feature, 16>;
 
 struct gpu_info
 {

--- a/src/phantasm-renderer/backend/types.hh
+++ b/src/phantasm-renderer/backend/types.hh
@@ -35,6 +35,9 @@ PR_DEFINE_HANDLE(shader_view);
 /// recorded command list, ready to submit or discard
 PR_DEFINE_HANDLE(command_list);
 
+/// synchronization primitive. can be "set" by a command_list after it completed executing
+PR_DEFINE_HANDLE(event);
+
 /// raytracing acceleration structure handle
 PR_DEFINE_HANDLE(accel_struct);
 

--- a/src/phantasm-renderer/backend/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-renderer/backend/vulkan/cmd_buf_translation.cc
@@ -17,7 +17,7 @@
 #include "resources/transition_barrier.hh"
 
 void pr::backend::vk::command_list_translator::translateCommandList(
-    VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size)
+    VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size, VkEvent event_to_set)
 {
     _cmd_list = list;
     _cmd_list_handle = list_handle;
@@ -35,6 +35,11 @@ void pr::backend::vk::command_list_translator::translateCommandList(
     {
         // end the last render pass
         vkCmdEndRenderPass(_cmd_list);
+    }
+
+    if (event_to_set != nullptr)
+    {
+        vkCmdSetEvent(_cmd_list, event_to_set, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     }
 
     // close the list

--- a/src/phantasm-renderer/backend/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-renderer/backend/vulkan/cmd_buf_translation.hh
@@ -45,7 +45,7 @@ struct command_list_translator
         _globals.initialize(device, sv_pool, resource_pool, pso_pool, cmd_pool, as_pool);
     }
 
-    void translateCommandList(VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size);
+    void translateCommandList(VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size, VkEvent event_to_set);
 
     void execute(cmd::begin_render_pass const& begin_rp);
 

--- a/src/phantasm-renderer/backend/vulkan/loader/vulkan_fwd.hh
+++ b/src/phantasm-renderer/backend/vulkan/loader/vulkan_fwd.hh
@@ -21,6 +21,7 @@ extern "C"
     PR_VK_DEFINE_HANDLE(VkRenderPass);
     PR_VK_DEFINE_HANDLE(VkCommandPool);
     PR_VK_DEFINE_HANDLE(VkFence);
+    PR_VK_DEFINE_HANDLE(VkEvent);
     PR_VK_DEFINE_HANDLE(VkSemaphore);
     PR_VK_DEFINE_HANDLE(VkAccelerationStructureNV);
 

--- a/src/phantasm-renderer/backend/vulkan/pools/event_pool.cc
+++ b/src/phantasm-renderer/backend/vulkan/pools/event_pool.cc
@@ -1,0 +1,75 @@
+#include "event_pool.hh"
+
+#include <phantasm-renderer/backend/vulkan/common/log.hh>
+#include <phantasm-renderer/backend/vulkan/common/verify.hh>
+#include <phantasm-renderer/backend/vulkan/loader/volk.hh>
+
+pr::backend::handle::event pr::backend::vk::EventPool::createEvent()
+{
+    unsigned pool_index;
+    {
+        auto lg = std::lock_guard(mMutex);
+        pool_index = mPool.acquire();
+    }
+
+    VkEventCreateInfo info = {};
+    info.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
+
+    VkEvent& new_event = mPool.get(pool_index);
+    PR_VK_VERIFY_SUCCESS(vkCreateEvent(mDevice, &info, nullptr, &new_event));
+
+    return {static_cast<handle::index_t>(pool_index)};
+}
+
+void pr::backend::vk::EventPool::free(pr::backend::handle::event event)
+{
+    if (!event.is_valid())
+        return;
+
+    VkEvent freed_event = mPool.get(static_cast<unsigned>(event.index));
+    vkDestroyEvent(mDevice, freed_event, nullptr);
+
+    {
+        auto lg = std::lock_guard(mMutex);
+        mPool.release(static_cast<unsigned>(event.index));
+    }
+}
+
+void pr::backend::vk::EventPool::free(cc::span<const pr::backend::handle::event> event_span)
+{
+    auto lg = std::lock_guard(mMutex);
+
+    for (auto as : event_span)
+    {
+        if (as.is_valid())
+        {
+            VkEvent freed_event = mPool.get(static_cast<unsigned>(as.index));
+            vkDestroyEvent(mDevice, freed_event, nullptr);
+            mPool.release(static_cast<unsigned>(as.index));
+        }
+    }
+}
+
+void pr::backend::vk::EventPool::initialize(VkDevice device, unsigned max_num_events)
+{
+    CC_ASSERT(mDevice == nullptr && "double init");
+    mDevice = device;
+    mPool.initialize(max_num_events);
+}
+
+void pr::backend::vk::EventPool::destroy()
+{
+    if (mDevice != nullptr)
+    {
+        auto num_leaks = 0;
+        mPool.iterate_allocated_nodes([&](VkEvent leaked_event, unsigned) {
+            ++num_leaks;
+            vkDestroyEvent(mDevice, leaked_event, nullptr);
+        });
+
+        if (num_leaks > 0)
+        {
+            log::info()("warning: leaked {} handle::event object{}", num_leaks, num_leaks == 1 ? "" : "s");
+        }
+    }
+}

--- a/src/phantasm-renderer/backend/vulkan/pools/event_pool.hh
+++ b/src/phantasm-renderer/backend/vulkan/pools/event_pool.hh
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <mutex>
+
+#include <phantasm-renderer/backend/detail/linked_pool.hh>
+#include <phantasm-renderer/backend/types.hh>
+
+#include <phantasm-renderer/backend/vulkan/loader/vulkan_fwd.hh>
+
+namespace pr::backend::vk
+{
+class EventPool
+{
+public:
+    [[nodiscard]] handle::event createEvent();
+
+    void free(handle::event event);
+    void free(cc::span<handle::event const> event_span);
+
+public:
+    void initialize(VkDevice device, unsigned max_num_events);
+    void destroy();
+
+    VkEvent get(handle::event event) const
+    {
+        CC_ASSERT(event.is_valid() && "invalid handle::event");
+        return mPool.get(static_cast<unsigned>(event.index));
+    }
+
+private:
+    VkDevice mDevice = nullptr;
+
+    backend::detail::linked_pool<VkEvent, unsigned> mPool;
+
+    std::mutex mMutex;
+};
+
+}


### PR DESCRIPTION
Simple synchronization primitive to track `handle::command_list`s that have finished executing. Non-blocking, not waitable. Prerequisite for frontend resource lifetime tracking.