### PR TITLE
Array render targets, minor improvements

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -20,7 +20,8 @@ public:
     CompiledFrame() = default;
     CompiledFrame(CompiledFrame const&) = delete;
     CompiledFrame& operator=(CompiledFrame const&) = delete;
-    CompiledFrame(CompiledFrame&& rhs) noexcept : parent(rhs.parent), event(rhs.event), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables))
+    CompiledFrame(CompiledFrame&& rhs) noexcept
+      : parent(rhs.parent), event(rhs.event), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables)), should_present_after_submit(rhs.should_present_after_submit)
     {
         rhs.parent = nullptr;
     }
@@ -34,6 +35,7 @@ public:
             event = rhs.event;
             cmdlist = rhs.cmdlist;
             freeables = cc::move(rhs.freeables);
+            should_present_after_submit = rhs.should_present_after_submit;
             rhs.parent = nullptr;
         }
 
@@ -44,8 +46,8 @@ public:
 
 private:
     friend class Context;
-    CompiledFrame(phi::handle::command_list cmdlist, phi::handle::event event, cc::vector<freeable_cached_obj>&& freeables)
-      : event(event), cmdlist(cmdlist), freeables(cc::move(freeables))
+    CompiledFrame(phi::handle::command_list cmdlist, phi::handle::event event, cc::vector<freeable_cached_obj>&& freeables, bool present_after_submit)
+      : event(event), cmdlist(cmdlist), freeables(cc::move(freeables)), should_present_after_submit(present_after_submit)
     {
     }
 
@@ -55,5 +57,6 @@ private:
     phi::handle::event event = phi::handle::null_event;
     phi::handle::command_list cmdlist = phi::handle::null_command_list;
     cc::vector<freeable_cached_obj> freeables;
+    bool should_present_after_submit = false;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -235,7 +235,7 @@ CompiledFrame Context::compile(raii::Frame&& frame)
     }
 }
 
-gpu_epoch_t Context::submit(raii::Frame&& frame) { return submit(cc::move(compile(cc::move(frame)))); }
+gpu_epoch_t Context::submit(raii::Frame&& frame) { return submit(compile(cc::move(frame))); }
 
 gpu_epoch_t Context::submit(CompiledFrame&& frame)
 {

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -219,7 +219,7 @@ cached_buffer Context::get_upload_buffer(unsigned size, unsigned stride, bool al
 }
 
 
-CompiledFrame Context::compile(raii::Frame& frame)
+CompiledFrame Context::compile(raii::Frame&& frame)
 {
     frame.finalize();
 
@@ -235,7 +235,7 @@ CompiledFrame Context::compile(raii::Frame& frame)
     }
 }
 
-gpu_epoch_t Context::submit(raii::Frame& frame) { return submit(compile(frame)); }
+gpu_epoch_t Context::submit(raii::Frame&& frame) { return submit(cc::move(compile(cc::move(frame)))); }
 
 gpu_epoch_t Context::submit(CompiledFrame&& frame)
 {

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -83,36 +83,16 @@ auto_texture Context::make_texture_array(tg::isize2 size, unsigned num_elems, ph
     return {createTexture(info), this};
 }
 
-auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples)
+auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size)
 {
-    auto const info = render_target_info{format, size.width, size.height, num_samples};
+    auto const info = render_target_info{format, size.width, size.height, num_samples, array_size};
     return {createRenderTarget(info), this};
 }
 
-auto_render_target Context::make_target(tg::isize2 size, phi::format format, tg::color4 optimized_clear_color, unsigned num_samples)
+auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, const phi::rt_clear_value& optimized_clear)
 {
-    CC_ASSERT(!phi::is_depth_format(format) && "using optimized clear color overload for depth render target");
-
-    phi::rt_clear_value clear_val;
-    clear_val.color[0] = optimized_clear_color.r;
-    clear_val.color[1] = optimized_clear_color.g;
-    clear_val.color[2] = optimized_clear_color.b;
-    clear_val.color[3] = optimized_clear_color.a;
-
-    auto const info = render_target_info{format, size.width, size.height, num_samples};
-    return {createRenderTarget(info, &clear_val), this};
-}
-
-auto_render_target Context::make_target(tg::isize2 size, phi::format format, float optimized_clear_depth, uint8_t optimized_clear_stencil, unsigned num_samples)
-{
-    CC_ASSERT(phi::is_depth_format(format) && "using optimized clear depth overload for color render target");
-
-    phi::rt_clear_value clear_val;
-    clear_val.depth_stencil.depth = optimized_clear_depth;
-    clear_val.depth_stencil.stencil = optimized_clear_stencil;
-
-    auto const info = render_target_info{format, size.width, size.height, num_samples};
-    return {createRenderTarget(info, &clear_val), this};
+    auto const info = render_target_info{format, size.width, size.height, num_samples, array_size};
+    return {createRenderTarget(info, &optimized_clear), this};
 }
 
 auto_buffer Context::make_buffer(unsigned size, unsigned stride, bool allow_uav)
@@ -220,9 +200,9 @@ std::byte* Context::get_buffer_map(const buffer& buffer)
     return mBackend->getMappedMemory(buffer.res.handle);
 }
 
-cached_render_target Context::get_target(tg::isize2 size, phi::format format, unsigned num_samples)
+cached_render_target Context::get_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size)
 {
-    auto const info = render_target_info{format, size.width, size.height, num_samples};
+    auto const info = render_target_info{format, size.width, size.height, num_samples, array_size};
     return {acquireRenderTarget(info), this};
 }
 
@@ -427,7 +407,7 @@ void Context::internalInitialize()
 
 render_target Context::createRenderTarget(const render_target_info& info, phi::rt_clear_value const* optimized_clear)
 {
-    return {{mBackend->createRenderTarget(info.format, {info.width, info.height}, info.num_samples, optimized_clear), acquireGuid()}, info};
+    return {{mBackend->createRenderTarget(info.format, {info.width, info.height}, info.num_samples, info.array_size, optimized_clear), acquireGuid()}, info};
 }
 
 texture Context::createTexture(const texture_info& info)

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -300,7 +300,7 @@ private:
 
     // components
     gpu_epoch_tracker mGpuEpochTracker;
-    std::atomic<uint64_t> mResourceGUID = {0};
+    std::atomic<uint64_t> mResourceGUID = {1}; // GUID 0 is invalid
 
     // caches (have dtors, members must be below backend ptr)
     multi_cache<render_target_info> mCacheRenderTargets;
@@ -312,6 +312,14 @@ private:
     single_cache<phi::handle::pipeline_state> mCacheComputePSOs;
     single_cache<phi::handle::shader_view> mCacheGraphicsSVs;
     single_cache<phi::handle::shader_view> mCacheComputeSVs;
+
+    // safety/assert state
+#ifdef CC_ENABLE_ASSERTIONS
+    struct
+    {
+        bool did_acquire_before_present = false;
+    } mSafetyState;
+#endif
 };
 
 inline auto_buffer Context::make_upload_buffer_for_texture(const texture& tex, unsigned num_mips)

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -145,7 +145,7 @@ public:
 
     /// compiles a frame (records the command list)
     /// heavy operation, try to thread this if possible
-    [[nodiscard]] CompiledFrame compile(raii::Frame& frame);
+    [[nodiscard]] CompiledFrame compile(raii::Frame&& frame);
 
     /// submits a previously compiled frame to the GPU
     /// returns an epoch that can be waited on using Context::wait_for_epoch()
@@ -153,7 +153,7 @@ public:
 
     /// convenience to compile and submit a frame in a single call
     /// returns an epoch that can be waited on using Context::wait_for_epoch()
-    gpu_epoch_t submit(raii::Frame& frame);
+    gpu_epoch_t submit(raii::Frame&& frame);
 
     /// discard a previously compiled frame
     void discard(CompiledFrame&& frame);

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -53,11 +53,9 @@ public:
     [[nodiscard]] auto_texture make_texture_array(tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
 
     /// create a render target
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1);
-    /// create a render target with an optimized clear color
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, tg::color4 optimized_clear_color, unsigned num_samples = 1);
-    /// create a render target with an optimized clear depth / stencil
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, float optimized_clear_depth, uint8_t optimized_clear_stencil = 0, unsigned num_samples = 1);
+    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+    /// create a render target with an optimized clear value
+    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value const& optimized_clear);
 
     /// create a buffer
     [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
@@ -87,7 +85,7 @@ public:
     // cache lookup API
     //
 
-    [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1);
+    [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
 
     [[nodiscard]] cached_buffer get_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
     [[nodiscard]] cached_buffer get_upload_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -93,6 +93,13 @@ public:
         mWriter.add_command(cmd);
     }
 
+    /// get a pointer to a buffer in order to write raw commands
+    [[nodiscard]] std::byte* write_raw_bytes(size_t num_bytes)
+    {
+        flushPendingTransitions();
+        return mWriter.write_raw_bytes(num_bytes);
+    }
+
     /// write multiple resource slice transitions - no state tracking
     void transition_slices(cc::span<phi::cmd::transition_image_slices::slice_transition_info const> slices);
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -50,6 +50,10 @@ public:
 
     /// start a compute pass from persisted PSO
     [[nodiscard]] ComputePass make_pass(compute_pipeline_state const& compute_pipeline) & { return {this, compute_pipeline._handle}; }
+
+    /// redirect intuitive misuse (graphics passes can only be created from framebuffers)
+    [[deprecated("did you mean .make_framebuffer(..).make_pass(..)?")]] void make_pass(graphics_pipeline_state const&) = delete;
+
     /// starta compute pass from a raw phi PSO
     [[nodiscard]] ComputePass make_pass(phi::handle::pipeline_state raw_pso) & { return {this, raw_pso}; }
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -51,9 +51,6 @@ public:
     /// start a compute pass from persisted PSO
     [[nodiscard]] ComputePass make_pass(compute_pipeline_state const& compute_pipeline) & { return {this, compute_pipeline._handle}; }
 
-    /// redirect intuitive misuse (graphics passes can only be created from framebuffers)
-    [[deprecated("did you mean .make_framebuffer(..).make_pass(..)?")]] void make_pass(graphics_pipeline_state const&) = delete;
-
     /// starta compute pass from a raw phi PSO
     [[nodiscard]] ComputePass make_pass(phi::handle::pipeline_state raw_pso) & { return {this, raw_pso}; }
 
@@ -64,6 +61,18 @@ public:
     void transition(texture const& res, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
     void transition(render_target const& res, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
     void transition(phi::handle::resource raw_resource, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
+
+    // redirect intuitive misuses
+    /// (graphics passes can only be created from framebuffers)
+    [[deprecated("did you mean .make_framebuffer(..).make_pass(..)?")]] void make_pass(graphics_pipeline_state const&) = delete;
+    /// frame must not be discarded while framebuffers/passes are alive
+    [[deprecated("pr::raii::Frame must stay alive while passes are used")]] ComputePass make_pass(compute_pipeline_state const&) && = delete;
+    [[deprecated("pr::raii::Frame must stay alive while passes are used")]] ComputePass make_pass(phi::handle::pipeline_state) && = delete;
+    [[deprecated("pr::raii::Frame must stay alive while passes are used")]] ComputePass make_pass(compute_pass_info const&) && = delete;
+    [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] Framebuffer make_framebuffer(phi::cmd::begin_render_pass const&) && = delete;
+    template <class... RTs>
+    [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] Framebuffer make_framebuffer(RTs const&...) && = delete;
+    [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] framebuffer_builder build_framebuffer() && = delete;
 
     //
     // commands

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -89,6 +89,7 @@ public:
     template <class CmdT>
     void write_raw_cmd(CmdT const& cmd)
     {
+        flushPendingTransitions();
         mWriter.add_command(cmd);
     }
 

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -49,6 +49,7 @@ public:
     [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pipeline_state const&) && = delete;
     [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(phi::handle::pipeline_state) && = delete;
     [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pass_info const&) && = delete;
+
 private:
     void destroy();
 

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -38,10 +38,17 @@ public:
     /// start a graphics pass from persisted PSO
     [[nodiscard]] GraphicsPass make_pass(graphics_pipeline_state const& graphics_pipeline) & { return {mParent, graphics_pipeline._handle}; }
 
+    /// starta graphics pass from a raw phi PSO
+    [[nodiscard]] GraphicsPass make_pass(phi::handle::pipeline_state raw_pso) & { return {mParent, raw_pso}; }
+
     /// fetch a PSO from cache
     /// this hits a OS mutex and might have to build a PSO (expensive)
     [[nodiscard]] GraphicsPass make_pass(graphics_pass_info const& gp) &;
 
+    // redirect intuitive misuses
+    [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pipeline_state const&) && = delete;
+    [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(phi::handle::pipeline_state) && = delete;
+    [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pass_info const&) && = delete;
 private:
     void destroy();
 

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -113,10 +113,10 @@ public:
         _info.get().uav_guids.push_back(rvi.guid);
     }
 
-    void add_sampler(phi::sampler_filter filter, unsigned anisotropy = 16u)
+    void add_sampler(phi::sampler_filter filter, unsigned anisotropy = 16u, phi::sampler_address_mode address_mode = phi::sampler_address_mode::wrap)
     {
         auto& new_sampler = _info.get().samplers.emplace_back();
-        new_sampler.init_default(filter, anisotropy);
+        new_sampler.init_default(filter, anisotropy, address_mode);
     }
 
     void add_sampler(phi::sampler_config const& config) { _info.get().samplers.push_back(config); }
@@ -211,10 +211,10 @@ public:
 
     // add samplers
 
-    argument_builder& add_sampler(phi::sampler_filter filter, unsigned anisotropy = 16u)
+    argument_builder& add_sampler(phi::sampler_filter filter, unsigned anisotropy = 16u, phi::sampler_address_mode address_mode = phi::sampler_address_mode::wrap)
     {
         auto& new_sampler = _samplers.emplace_back();
-        new_sampler.init_default(filter, anisotropy);
+        new_sampler.init_default(filter, anisotropy, address_mode);
         return *this;
     }
 

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -65,6 +65,14 @@ struct resource_view_info
     return res;
 }
 
+[[nodiscard]] inline resource_view_info resource_view_2d(render_target const& tex, unsigned mip_start = 0, unsigned mip_size = unsigned(-1))
+{
+    resource_view_info res;
+    res.guid = tex.res.guid;
+    res.rv.init_as_tex2d(tex.res.handle, tex.info.format, false, mip_start, mip_size);
+    return res;
+}
+
 [[nodiscard]] inline resource_view_info resource_view_cube(texture const& tex)
 {
     resource_view_info res;

--- a/src/phantasm-renderer/common/growing_writer.hh
+++ b/src/phantasm-renderer/common/growing_writer.hh
@@ -22,8 +22,17 @@ struct growing_writer
         _writer.add_command(cmd);
     }
 
+    [[nodiscard]] std::byte* write_raw_bytes(size_t amount)
+    {
+        accomodate(amount);
+        auto* const res = _writer.buffer_head();
+        _writer.advance_cursor(amount);
+        return res;
+    }
+
     size_t size() const { return _writer.size(); }
     std::byte* buffer() const { return _writer.buffer(); }
+    std::byte* buffer_head() const { return _writer.buffer_head(); }
     size_t max_size() const { return _writer.max_size(); }
     bool is_empty() const { return _writer.empty(); }
 

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -12,10 +12,11 @@ struct render_target_info
     int width;
     int height;
     unsigned num_samples;
+    unsigned array_size;
 
     constexpr bool operator==(render_target_info const& rhs) const noexcept
     {
-        return format == rhs.format && width == rhs.width && height == rhs.height && num_samples == rhs.num_samples;
+        return format == rhs.format && width == rhs.width && height == rhs.height && num_samples == rhs.num_samples && array_size == rhs.array_size;
     }
 };
 
@@ -51,7 +52,10 @@ struct buffer_info
 
 struct resource_info_hasher
 {
-    constexpr size_t operator()(render_target_info const& rt) const noexcept { return cc::make_hash(rt.format, rt.width, rt.height, rt.num_samples); }
+    constexpr size_t operator()(render_target_info const& rt) const noexcept
+    {
+        return cc::make_hash(rt.format, rt.width, rt.height, rt.num_samples, rt.array_size);
+    }
 
     constexpr size_t operator()(texture_info const& t) const noexcept
     {


### PR DESCRIPTION
- Add support for texture array render targets
- Simplify optimized clear value API
- Fix and expand raw phi command writing to `Frame`
- Add assert for presents without prior backbuffer acquire
- Add intuitive-error redirects as deprecated deleted methods on `Frame` and `Framebuffer`