### PR TITLE
Blendstate for cached PSOs, sample amount asserts

### DIFF
--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -40,7 +40,7 @@ public:
 
         // add targets
         (addRenderTargetToFramebuffer(bcmd, num_samples, targets), ...);
-        return buildFramebuffer(bcmd, num_samples);
+        return buildFramebuffer(bcmd, num_samples, nullptr);
     }
 
     /// create a framebuffer from a raw phi command
@@ -174,7 +174,7 @@ private:
     // framebuffer_builder-side API
 private:
     friend struct framebuffer_builder;
-    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples);
+    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples, const phi::arg::framebuffer_config *blendstate_override);
 
     // Framebuffer-side API
 private:

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -174,7 +174,7 @@ private:
     // framebuffer_builder-side API
 private:
     friend struct framebuffer_builder;
-    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples, const phi::arg::framebuffer_config *blendstate_override);
+    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples, const phi::arg::framebuffer_config* blendstate_override);
 
     // Framebuffer-side API
 private:

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -29,14 +29,18 @@ public:
     template <class... RTs>
     [[nodiscard]] Framebuffer make_framebuffer(RTs const&... targets) &
     {
+        static_assert(sizeof...(RTs) > 0, "at least one render target required");
+
         phi::cmd::begin_render_pass bcmd;
         // initialize command
         bcmd.set_null_depth_stencil();
         bcmd.viewport = tg::isize2(1 << 30, 1 << 30);
 
+        int num_samples = -1;
+
         // add targets
-        (addRenderTarget(bcmd, targets), ...);
-        return buildFramebuffer(bcmd);
+        (addRenderTargetToFramebuffer(bcmd, num_samples, targets), ...);
+        return buildFramebuffer(bcmd, num_samples);
     }
 
     /// create a framebuffer from a raw phi command
@@ -156,7 +160,7 @@ public:
 
     // private
 private:
-    static void addRenderTarget(phi::cmd::begin_render_pass& bcmd, render_target const& rt);
+    static void addRenderTargetToFramebuffer(phi::cmd::begin_render_pass& bcmd, int& num_samples, render_target const& rt);
 
     void flushPendingTransitions();
 
@@ -170,14 +174,14 @@ private:
     // framebuffer_builder-side API
 private:
     friend struct framebuffer_builder;
-    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd);
+    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples);
 
     // Framebuffer-side API
 private:
     friend class Framebuffer;
     void framebufferOnJoin(Framebuffer const&);
 
-    phi::handle::pipeline_state framebufferAcquireGraphicsPSO(pr::graphics_pass_info const& gp, pr::framebuffer_info const& fb);
+    phi::handle::pipeline_state framebufferAcquireGraphicsPSO(pr::graphics_pass_info const& gp, pr::framebuffer_info const& fb, int fb_inferred_num_samples);
 
     // Pass-side API
 private:

--- a/src/phantasm-renderer/Framebuffer.cc
+++ b/src/phantasm-renderer/Framebuffer.cc
@@ -15,4 +15,7 @@ void pr::raii::Framebuffer::destroy()
         mParent->framebufferOnJoin(*this);
 }
 
-pr::raii::Framebuffer pr::raii::framebuffer_builder::make() { return _parent->buildFramebuffer(_cmd, _num_samples); }
+pr::raii::Framebuffer pr::raii::framebuffer_builder::make()
+{
+    return _parent->buildFramebuffer(_cmd, _num_samples, _has_custom_blendstate ? &_blendstate_overrides : nullptr);
+}

--- a/src/phantasm-renderer/Framebuffer.cc
+++ b/src/phantasm-renderer/Framebuffer.cc
@@ -6,7 +6,7 @@ pr::raii::Framebuffer::~Framebuffer() { destroy(); }
 
 pr::raii::GraphicsPass pr::raii::Framebuffer::make_pass(const pr::graphics_pass_info& gp) &
 {
-    return {mParent, mParent->framebufferAcquireGraphicsPSO(gp, mHashInfo)};
+    return {mParent, mParent->framebufferAcquireGraphicsPSO(gp, mHashInfo, mNumSamples)};
 }
 
 void pr::raii::Framebuffer::destroy()
@@ -15,4 +15,4 @@ void pr::raii::Framebuffer::destroy()
         mParent->framebufferOnJoin(*this);
 }
 
-pr::raii::Framebuffer pr::raii::framebuffer_builder::make() { return _parent->buildFramebuffer(_cmd); }
+pr::raii::Framebuffer pr::raii::framebuffer_builder::make() { return _parent->buildFramebuffer(_cmd, _num_samples); }

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -26,9 +26,9 @@ public:
         new (&_storage.value) T();                  // call default ctor
     }
 
-    // copy ctor/assign is memcpy to preserve the memset padding
-    hashable_storage(hashable_storage const& rhs) { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
-    hashable_storage& operator=(hashable_storage const& rhs)
+    // copy ctor/assign is memcpy to preserve the memset padding - noexcept to allow noexcept default move in outer types
+    hashable_storage(hashable_storage const& rhs) noexcept { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
+    hashable_storage& operator=(hashable_storage const& rhs) noexcept
     {
         if (this != &rhs)
             std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T));

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -30,8 +30,13 @@ public:
     hashable_storage(hashable_storage const& rhs) { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
     hashable_storage& operator=(hashable_storage const& rhs) { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
 
-    hashable_storage(hashable_storage&&) = delete;
-    hashable_storage& operator=(hashable_storage&&) = delete;
+    hashable_storage(hashable_storage&& rhs) noexcept { std::memcpy(&_storage, &rhs._storage, sizeof(_storage)); }
+    hashable_storage& operator=(hashable_storage&& rhs) noexcept
+    {
+        if (this != &rhs)
+            std::memcpy(&_storage, &rhs._storage, sizeof(_storage));
+        return *this;
+    }
 
     // with the established guarantees, hashing and comparison are trivial
     void get_murmur(murmur_hash& out) const { murmurhash3_x64_128(&_storage.value, sizeof(T), 0, out); }

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -28,15 +28,15 @@ public:
 
     // copy ctor/assign is memcpy to preserve the memset padding
     hashable_storage(hashable_storage const& rhs) { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
-    hashable_storage& operator=(hashable_storage const& rhs) { std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T)); }
-
-    hashable_storage(hashable_storage&& rhs) noexcept { std::memcpy(&_storage, &rhs._storage, sizeof(_storage)); }
-    hashable_storage& operator=(hashable_storage&& rhs) noexcept
+    hashable_storage& operator=(hashable_storage const& rhs)
     {
         if (this != &rhs)
-            std::memcpy(&_storage, &rhs._storage, sizeof(_storage));
+            std::memcpy(&_storage.value, &rhs._storage.value, sizeof(T));
         return *this;
     }
+
+    hashable_storage(hashable_storage&& rhs) noexcept = delete;
+    hashable_storage& operator=(hashable_storage&& rhs) noexcept = delete;
 
     // with the established guarantees, hashing and comparison are trivial
     void get_murmur(murmur_hash& out) const { murmurhash3_x64_128(&_storage.value, sizeof(T), 0, out); }

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -10,10 +10,12 @@ enum class backend
     vulkan
 };
 
+// enum renames
 using shader = phi::shader_stage;
 using format = phi::format;
 using state = phi::resource_state;
 
+// enum passthroughs
 using phi::blend_factor;
 using phi::blend_logic_op;
 using phi::blend_op;
@@ -21,4 +23,7 @@ using phi::sampler_address_mode;
 using phi::sampler_border_color;
 using phi::sampler_compare_func;
 using phi::sampler_filter;
+
+// struct passthroughs
+using phi::blend_state;
 }


### PR DESCRIPTION
- Add asserts about inconsistent sample amounts in a framebuffer
- Add blendstate override settings to framebuffer_builder affecting cache-access PSOs