### PR TITLE
Frame::debug_marker, skip transitions on mapped buffers

### DIFF
--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -33,6 +33,9 @@ raii::ComputePass raii::Frame::make_pass(const compute_pass_info& cp) & { return
 
 void raii::Frame::transition(const buffer& res, phi::resource_state target, phi::shader_stage_flags_t dependency)
 {
+    if (res.info.is_mapped) // mapped buffers are never transitioned
+        return;
+
     transition(res.res.handle, target, dependency);
 }
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -91,6 +91,8 @@ public:
     void resolve(render_target const& src, texture const& dest);
     void resolve(render_target const& src, render_target const& dest);
 
+    void debug_marker(char const* label) { write_raw_cmd(phi::cmd::debug_marker{label}); }
+
     //
     // specials
 


### PR DESCRIPTION
(upload buffers must remain locked in their state)