### PR TITLE
Cache management, readback buffers, minor improvements

### DIFF
--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -98,13 +98,19 @@ auto_render_target Context::make_target(tg::isize2 size, phi::format format, uns
 
 auto_buffer Context::make_buffer(unsigned size, unsigned stride, bool allow_uav)
 {
-    auto const info = buffer_info{size, stride, allow_uav, false};
+    auto const info = buffer_info{size, stride, allow_uav, buffer_info::unmapped};
     return {createBuffer(info), this};
 }
 
-auto_buffer Context::make_upload_buffer(unsigned size, unsigned stride, bool allow_uav)
+auto_buffer Context::make_upload_buffer(unsigned size, unsigned stride)
 {
-    auto const info = buffer_info{size, stride, allow_uav, true};
+    auto const info = buffer_info{size, stride, false, buffer_info::mapped_upload};
+    return {createBuffer(info), this};
+}
+
+auto_buffer Context::make_readback_buffer(unsigned size, unsigned stride)
+{
+    auto const info = buffer_info{size, stride, false, buffer_info::mapped_readback};
     return {createBuffer(info), this};
 }
 
@@ -183,20 +189,20 @@ void Context::free_to_cache(const render_target& rt) { freeCachedTarget(rt.info,
 
 void Context::write_buffer(const buffer& buffer, void const* data, size_t size, size_t offset)
 {
-    CC_ASSERT(buffer.info.is_mapped && "Attempted to write to non-mapped buffer");
+    CC_ASSERT(buffer.info.map == buffer_info::mapped_upload && "Attempted to write to non-upload buffer");
     CC_ASSERT(buffer.info.size_bytes >= size && "Buffer write out of bounds");
     std::memcpy(mBackend->getMappedMemory(buffer.res.handle) + offset, data, size);
 }
 
 void Context::flush_buffer_writes(const buffer& buffer)
 {
-    CC_ASSERT(buffer.info.is_mapped && "Attempted to flush writes to non-mapped buffer");
+    CC_ASSERT(buffer.info.map == buffer_info::mapped_upload && "Attempted to flush writes to non-upload buffer");
     mBackend->flushMappedMemory(buffer.res.handle);
 }
 
 std::byte* Context::get_buffer_map(const buffer& buffer)
 {
-    CC_ASSERT(buffer.info.is_mapped && "Attempted to get map from non-mapped buffer");
+    CC_ASSERT(buffer.info.map != buffer_info::unmapped && "Attempted to get map from non-mapped buffer");
     return mBackend->getMappedMemory(buffer.res.handle);
 }
 
@@ -208,13 +214,19 @@ cached_render_target Context::get_target(tg::isize2 size, phi::format format, un
 
 cached_buffer Context::get_buffer(unsigned size, unsigned stride, bool allow_uav)
 {
-    auto const info = buffer_info{size, stride, allow_uav, false};
+    auto const info = buffer_info{size, stride, allow_uav, buffer_info::unmapped};
     return {acquireBuffer(info), this};
 }
 
-cached_buffer Context::get_upload_buffer(unsigned size, unsigned stride, bool allow_uav)
+cached_buffer Context::get_upload_buffer(unsigned size, unsigned stride)
 {
-    auto const info = buffer_info{size, stride, allow_uav, true};
+    auto const info = buffer_info{size, stride, false, buffer_info::mapped_upload};
+    return {acquireBuffer(info), this};
+}
+
+cached_buffer Context::get_readback_buffer(unsigned size, unsigned stride)
+{
+    auto const info = buffer_info{size, stride, false, buffer_info::mapped_readback};
     return {acquireBuffer(info), this};
 }
 
@@ -477,15 +489,23 @@ texture Context::createTexture(const texture_info& info)
 
 buffer Context::createBuffer(const buffer_info& info)
 {
+    CC_ASSERT((info.allow_uav ? info.map == buffer_info::unmapped : true) && "mapped buffers cannot be created with UAV support");
+
     phi::handle::resource handle;
-    if (info.is_mapped)
+
+    switch (info.map)
     {
-        handle = mBackend->createUploadBuffer(info.size_bytes, info.stride_bytes);
-    }
-    else
-    {
+    case buffer_info::unmapped:
         handle = mBackend->createBuffer(info.size_bytes, info.stride_bytes, info.allow_uav);
+        break;
+    case buffer_info::mapped_upload:
+        handle = mBackend->createUploadBuffer(info.size_bytes, info.stride_bytes);
+        break;
+    case buffer_info::mapped_readback:
+        handle = mBackend->createReadbackBuffer(info.size_bytes, info.stride_bytes);
+        break;
     }
+
     return {{handle, acquireGuid()}, info};
 }
 

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -60,9 +60,11 @@ public:
     /// create a buffer
     [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
     /// create a mapped upload buffer which can be directly written to from CPU
-    [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
+    [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0);
     /// create a mapped upload buffer, with a size based on accomodating a given texture's contents
     [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1);
+    /// create a mapped readback buffer which can be directly read from CPU
+    [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0);
 
     /// create a shader from binary data
     [[nodiscard]] auto_shader_binary make_shader(std::byte const* data, size_t size, pr::shader stage);
@@ -88,7 +90,8 @@ public:
     [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
 
     [[nodiscard]] cached_buffer get_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
-    [[nodiscard]] cached_buffer get_upload_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
+    [[nodiscard]] cached_buffer get_upload_buffer(unsigned size, unsigned stride = 0);
+    [[nodiscard]] cached_buffer get_readback_buffer(unsigned size, unsigned stride = 0);
 
 
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -174,6 +174,22 @@ public:
     [[nodiscard]] render_target acquire_backbuffer();
 
     //
+    // cache management
+    //
+
+    /// frees all resources (textures, rendertargets, buffers) from pr caches that are not acquired or in flight
+    /// returns amount of freed elements
+    unsigned clear_resource_caches();
+
+    /// frees all shader_views from pr caches that are not acquired or in flight
+    /// returns amount of freed elements
+    unsigned clear_shader_view_cache();
+
+    /// frees all pipeline_states from pr caches that are not acquired or in flight
+    /// returns amount of freed elements
+    unsigned clear_pipeline_state_cache();
+
+    //
     // info
     //
 

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -33,7 +33,7 @@ raii::ComputePass raii::Frame::make_pass(const compute_pass_info& cp) & { return
 
 void raii::Frame::transition(const buffer& res, phi::resource_state target, phi::shader_stage_flags_t dependency)
 {
-    if (res.info.is_mapped) // mapped buffers are never transitioned
+    if (res.info.map != buffer_info::unmapped) // mapped buffers are never transitioned
         return;
 
     transition(res.res.handle, target, dependency);

--- a/src/phantasm-renderer/argument.cc
+++ b/src/phantasm-renderer/argument.cc
@@ -4,56 +4,6 @@
 
 #include "Context.hh"
 
-void pr::argument::add(const texture& img)
-{
-    _info.get().srv_guids.push_back(img.res.guid);
-
-    auto& new_rv = _info.get().srvs.emplace_back();
-    fill_default_srv(new_rv, img, 0, unsigned(-1));
-}
-
-void pr::argument::add(const pr::buffer& buffer)
-{
-    CC_ASSERT(buffer.info.stride_bytes > 0 && "buffer used as SRV argument has no stride, pass a stride during creation");
-    _info.get().srv_guids.push_back(buffer.res.guid);
-
-    auto& new_rv = _info.get().srvs.emplace_back();
-    new_rv.init_as_structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes);
-}
-
-void pr::argument::add(const pr::render_target& rt)
-{
-    _info.get().srv_guids.push_back(rt.res.guid);
-
-    auto& new_rv = _info.get().srvs.emplace_back();
-    new_rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
-}
-
-void pr::argument::add_mutable(const pr::texture& img)
-{
-    _info.get().uav_guids.push_back(img.res.guid);
-
-    auto& new_rv = _info.get().uavs.emplace_back();
-    fill_default_uav(new_rv, img, 0, unsigned(-1));
-}
-
-void pr::argument::add_mutable(const pr::buffer& buffer)
-{
-    CC_ASSERT(buffer.info.stride_bytes > 0 && "buffer used as UAV argument has no stride, pass a stride during creation");
-    _info.get().uav_guids.push_back(buffer.res.guid);
-
-    auto& new_rv = _info.get().uavs.emplace_back();
-    new_rv.init_as_structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes);
-}
-
-void pr::argument::add_mutable(const pr::render_target& rt)
-{
-    _info.get().uav_guids.push_back(rt.res.guid);
-
-    auto& new_rv = _info.get().uavs.emplace_back();
-    new_rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
-}
-
 void pr::argument::fill_default_srv(phi::resource_view& new_rv, const pr::texture& img, unsigned mip_start, unsigned mip_size)
 {
     new_rv.resource = img.res.handle;

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -13,8 +13,6 @@
 
 namespace pr
 {
-class Context;
-
 struct resource_view_info
 {
     resource_view_info& format(pr::format fmt)
@@ -120,6 +118,10 @@ public:
     }
 
     void add_sampler(phi::sampler_config const& config) { _info.get().samplers.push_back(config); }
+
+    unsigned get_num_srvs() const { return unsigned(_info.get().srvs.size()); }
+    unsigned get_num_uavs() const { return unsigned(_info.get().uavs.size()); }
+    unsigned get_num_samplers() const { return unsigned(_info.get().samplers.size()); }
 
 private:
     friend struct argument_builder;

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -39,14 +39,21 @@ struct texture_info
 
 struct buffer_info
 {
+    enum map_type : uint8_t
+    {
+        unmapped = 0,
+        mapped_upload,
+        mapped_readback
+    };
+
     unsigned size_bytes;
     unsigned stride_bytes;
     bool allow_uav;
-    bool is_mapped;
+    map_type map;
 
     constexpr bool operator==(buffer_info const& rhs) const noexcept
     {
-        return size_bytes == rhs.size_bytes && stride_bytes == rhs.stride_bytes && allow_uav == rhs.allow_uav && is_mapped == rhs.is_mapped;
+        return size_bytes == rhs.size_bytes && stride_bytes == rhs.stride_bytes && allow_uav == rhs.allow_uav && map == rhs.map;
     }
 };
 
@@ -62,6 +69,6 @@ struct resource_info_hasher
         return cc::make_hash(t.fmt, t.dim, t.allow_uav, t.width, t.height, t.depth_or_array_size, t.num_mips);
     }
 
-    constexpr size_t operator()(buffer_info const& b) const noexcept { return cc::make_hash(b.size_bytes, b.stride_bytes, b.allow_uav, b.is_mapped); }
+    constexpr size_t operator()(buffer_info const& b) const noexcept { return cc::make_hash(b.size_bytes, b.stride_bytes, b.allow_uav, b.map); }
 };
 }

--- a/src/phantasm-renderer/common/single_cache.hh
+++ b/src/phantasm-renderer/common/single_cache.hh
@@ -59,12 +59,19 @@ public:
     }
 
     template <class F>
-    void cull(gpu_epoch_t current_gpu_epoch, F&& destroy_func)
+    void cull_all(gpu_epoch_t current_gpu_epoch, F&& destroy_func)
     {
         auto lg = std::lock_guard(_mutex);
-        auto const f_can_cull = [&](map_element const& elem) { return elem.num_references == 0 && elem.required_gpu_epoch <= current_gpu_epoch; };
+        auto f_can_cull = [&](map_element const& elem) { return elem.num_references == 0 && elem.required_gpu_epoch <= current_gpu_epoch; };
 
-        // TODO: go through section of the map and destroy element based on condition above
+        for (auto&& [key, elem] : _map)
+        {
+            if (f_can_cull(elem))
+            {
+                destroy_func(elem.val);
+                CC_RUNTIME_ASSERT(false && "cc::map remove unimplemented and required here");
+            }
+        }
     }
 
     template <class F>

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -26,4 +26,5 @@ using phi::sampler_filter;
 
 // struct passthroughs
 using phi::blend_state;
+using phi::sampler_config;
 }

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -6,6 +6,7 @@
 
 #include <phantasm-renderer/common/hashable_storage.hh>
 
+#include <phantasm-renderer/argument.hh>
 #include <phantasm-renderer/common/state_info.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
@@ -14,9 +15,6 @@
 
 namespace pr
 {
-class Context;
-class Frame;
-
 struct graphics_pass_info
 {
 public:
@@ -25,6 +23,12 @@ public:
     {
         _storage.get().arg_shapes.push_back({num_srvs, num_uavs, num_samplers, has_cbv});
         return *this;
+    }
+
+    /// add a shader argument matching the shape of a given pr::argument
+    graphics_pass_info& arg(argument const& argument, bool has_cbv = false)
+    {
+        return arg(argument.get_num_srvs(), argument.get_num_uavs(), argument.get_num_samplers(), has_cbv);
     }
 
     /// Add root constants
@@ -124,6 +128,12 @@ public:
     {
         _storage.get().arg_shapes.push_back({num_srvs, num_uavs, num_samplers, has_cbv});
         return *this;
+    }
+
+    /// add a shader argument matching the shape of a given pr::argument
+    compute_pass_info& arg(argument const& argument, bool has_cbv = false)
+    {
+        return arg(argument.get_num_srvs(), argument.get_num_uavs(), argument.get_num_samplers(), has_cbv);
     }
 
     /// Add root constants


### PR DESCRIPTION
- Add `Context` methods to fully clear pr caches
- Add `make_readback_buffer`, `get_readback_buffer`
- Remove incorrect `allow_uav` paramter for `make_/get_upload_buffer`
- Add `graphics_/compute_pass_info::arg` overload for `pr::argument const&`
- Add improved error messages for full `pr::argument`s