### PR TITLE
Adapt to phi and rich-log changes (breaking), add untyped API

### DIFF
--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -208,13 +208,23 @@ void Context::free_to_cache(const texture& texture) { freeCachedTexture(texture.
 
 void Context::free_to_cache(const render_target& rt) { freeCachedTarget(rt.info, rt.res); }
 
-void Context::write_buffer(const buffer& buffer, void const* data, size_t size, size_t offset)
+void Context::write_to_buffer(const buffer& buffer, void const* data, size_t size, size_t offset_in_buffer)
 {
     CC_ASSERT(buffer.info.heap == phi::resource_heap::upload && "Attempted to write to non-upload buffer");
-    CC_ASSERT(buffer.info.size_bytes >= size && "Buffer write out of bounds");
+    CC_ASSERT(buffer.info.size_bytes >= size + offset_in_buffer && "Buffer write out of bounds");
 
     auto* const map = map_buffer(buffer);
-    std::memcpy(map + offset, data, size);
+    std::memcpy(map + offset_in_buffer, data, size);
+    unmap_buffer(buffer);
+}
+
+void Context::read_from_buffer(const buffer& buffer, void* out_data, size_t size, size_t offset_in_buffer)
+{
+    CC_ASSERT(buffer.info.heap == phi::resource_heap::upload && "Attempted to read from non-readback buffer");
+    CC_ASSERT(buffer.info.size_bytes >= size + offset_in_buffer && "Buffer read out of bounds");
+
+    auto* const map = map_buffer(buffer);
+    std::memcpy(out_data, map + offset_in_buffer, size);
     unmap_buffer(buffer);
 }
 

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -264,6 +264,7 @@ raw_resource Context::make_untyped_unlocked(const generic_resource_info& info)
         return createBuffer(info.info_buffer).res;
     default:
         CC_ASSERT(false && "invalid type");
+        return {};
     }
     CC_UNREACHABLE("invalid type");
 }
@@ -280,6 +281,7 @@ raw_resource Context::get_untyped_unlocked(const generic_resource_info& info)
         return acquireBuffer(info.info_buffer).res;
     default:
         CC_ASSERT(false && "invalid type");
+        return {};
     }
     CC_UNREACHABLE("invalid type");
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -196,6 +196,8 @@ void Context::free_to_cache_untyped(const raw_resource& resource, const generic_
         return freeCachedTexture(info.info_texture, resource);
     case phi::arg::create_resource_info::e_resource_buffer:
         return freeCachedBuffer(info.info_buffer, resource);
+    default:
+        CC_ASSERT(false && "invalid type");
     }
     CC_UNREACHABLE("invalid type");
 }
@@ -260,6 +262,8 @@ raw_resource Context::make_untyped_unlocked(const generic_resource_info& info)
         return createTexture(info.info_texture).res;
     case phi::arg::create_resource_info::e_resource_buffer:
         return createBuffer(info.info_buffer).res;
+    default:
+        CC_ASSERT(false && "invalid type");
     }
     CC_UNREACHABLE("invalid type");
 }
@@ -274,6 +278,8 @@ raw_resource Context::get_untyped_unlocked(const generic_resource_info& info)
         return acquireTexture(info.info_texture).res;
     case phi::arg::create_resource_info::e_resource_buffer:
         return acquireBuffer(info.info_buffer).res;
+    default:
+        CC_ASSERT(false && "invalid type");
     }
     CC_UNREACHABLE("invalid type");
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -33,7 +33,7 @@ phi::sc::target stage_to_sc_target(phi::shader_stage stage)
     case phi::shader_stage::compute:
         return phi::sc::target::compute;
     default:
-        LOG_WARN(pr::logger, "Unsupported shader stage for online compilation");
+        PR_LOG_WARN("Unsupported shader stage for online compilation");
         return phi::sc::target::pixel;
     }
 }
@@ -147,7 +147,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     if (bin.data == nullptr)
     {
-        LOG_WARN(pr::logger, "Failed to compile shader");
+        PR_LOG_WARN("Failed to compile shader");
         return {};
     }
     else

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -33,7 +33,7 @@ phi::sc::target stage_to_sc_target(phi::shader_stage stage)
     case phi::shader_stage::compute:
         return phi::sc::target::compute;
     default:
-        LOG_WARN(pr::pr_log, "Unsupported shader stage for online compilation");
+        LOG_WARN(pr::logger, "Unsupported shader stage for online compilation");
         return phi::sc::target::pixel;
     }
 }
@@ -147,7 +147,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     if (bin.data == nullptr)
     {
-        LOG_WARN(pr::pr_log, "Failed to compile shader");
+        LOG_WARN(pr::logger, "Failed to compile shader");
         return {};
     }
     else
@@ -411,7 +411,7 @@ render_target Context::acquire_backbuffer()
 #ifdef CC_ENABLE_ASSERTIONS
     mSafetyState.did_acquire_before_present = true;
 #endif
-    return {{backbuffer, backbuffer.is_valid() ? acquireGuid() : 0}, {mBackend->getBackbufferFormat(), size.width, size.height, 1, 1}};
+    return {{backbuffer, backbuffer.is_valid() ? acquireGuid() : 0}, {mBackend->getBackbufferFormat(), size.width, size.height, 1, 1, {0, 0, 0, 1}}};
 }
 
 unsigned Context::clear_resource_caches()

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -1,7 +1,5 @@
 #include "Context.hh"
 
-#include <rich-log/log.hh>
-
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/config.hh>
 #include <phantasm-hardware-interface/detail/byte_util.hh>
@@ -10,6 +8,7 @@
 
 #include <phantasm-renderer/CompiledFrame.hh>
 #include <phantasm-renderer/Frame.hh>
+#include <phantasm-renderer/common/log.hh>
 #include <phantasm-renderer/common/murmur_hash.hh>
 #include <phantasm-renderer/detail/backends.hh>
 
@@ -34,7 +33,7 @@ phi::sc::target stage_to_sc_target(phi::shader_stage stage)
     case phi::shader_stage::compute:
         return phi::sc::target::compute;
     default:
-        LOG(warning)("Unsupported shader stage for online compilation");
+        LOG_WARN(pr::pr_log, "Unsupported shader stage for online compilation");
         return phi::sc::target::pixel;
     }
 }
@@ -148,7 +147,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     if (bin.data == nullptr)
     {
-        LOG(warning)("Failed to compile shader");
+        LOG_WARN(pr::pr_log, "Failed to compile shader");
         return {};
     }
     else

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -165,9 +165,17 @@ public:
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer(buffer const& buffer, void const* data, size_t size, size_t offset_in_buffer = 0);
+    void write_to_buffer(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0)
+    {
+        write_to_buffer(buffer, data.data(), data.size(), offset_in_buffer);
+    }
 
     /// map a readback buffer, memcpy its contents to the provided location, and unmap it
     void read_from_buffer(buffer const& buffer, void* out_data, size_t size, size_t offset_in_buffer = 0);
+    void read_from_buffer(buffer const& buffer, cc::span<std::byte> out_data, size_t offset_in_buffer = 0)
+    {
+        read_from_buffer(buffer, out_data.data(), out_data.size(), offset_in_buffer);
+    }
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     template <class T>

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -178,21 +178,21 @@ public:
     }
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
+    /// data can be POD, or a container with POD elements (ie. cc::vector<int>)
     template <class T>
     void write_to_buffer_t(buffer const& buffer, T const& data, size_t offset_in_buffer = 0)
     {
         static_assert(!std::is_pointer_v<T>, "[pr::Context::write_to_buffer_t] Pointer instead of raw data provided");
-        static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::write_to_buffer_t] Non-trivially copyable data provided");
-        write_to_buffer(buffer, &data, sizeof(T), offset_in_buffer);
+        write_to_buffer(buffer, cc::as_byte_span<T const>(data), offset_in_buffer);
     }
 
     /// map a readback buffer, memcpy its contents to the provided location, and unmap it
+    /// data can be POD, or a container with POD elements (ie. cc::vector<int>)
     template <class T>
     void read_from_buffer_t(buffer const& buffer, T& out_data, size_t offset_in_buffer = 0)
     {
         static_assert(!std::is_pointer_v<T>, "[pr::Context::read_from_buffer_t] Pointer instead of raw data provided");
-        static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::read_from_buffer_t] Non-trivially copyable data provided");
-        read_from_buffer(buffer, &out_data, sizeof(T), offset_in_buffer);
+        read_from_buffer(buffer, cc::as_byte_span<T>(out_data), offset_in_buffer);
     }
 
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -138,9 +138,9 @@ public:
         write_buffer(buffer, &data, sizeof(T));
     }
 
-    void flush_buffer_writes(buffer const& buffer);
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
 
-    [[nodiscard]] std::byte* get_buffer_map(buffer const& buffer);
+    void unmap_buffer(buffer const& buffer);
 
     //
     // consumption API

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -315,18 +315,20 @@ public:
     template <class T, bool Cached>
     void free_to_cache(auto_destroyer<T, Cached> const&) = delete;
 
-    // ref type
+private:
+    //
+    // internal from here on out
+    //
+
 private:
     Context(Context const&) = delete;
     Context(Context&&) = delete;
     Context& operator=(Context const&) = delete;
     Context& operator=(Context&&) = delete;
 
-    // internal
 private:
     [[nodiscard]] uint64_t acquireGuid();
 
-private:
     void internalInitialize();
 
     // creation
@@ -351,13 +353,6 @@ private:
     void freeCachedTexture(texture_info const& info, raw_resource res);
     void freeCachedBuffer(buffer_info const& info, raw_resource res);
 
-    // internal builder API
-private:
-    friend struct pipeline_builder;
-    friend struct argument_builder;
-
-    // internal argument builder API
-private:
     // single cache access, Frame-side API
 private:
     friend class raii::Frame;

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -155,18 +155,36 @@ public:
     // buffer map API
     //
 
+    /// map a buffer created on the upload or readback heap in order to access it on CPU
+    /// a buffer can be mapped multiple times at once
     [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
 
+    /// unmap a buffer previously mapped using map_buffer
+    /// a buffer can be destroyed while mapped
     void unmap_buffer(buffer const& buffer);
 
-    void write_buffer(buffer const& buffer, void const* data, size_t size, size_t offset = 0);
+    /// map an upload buffer, memcpy the provided data into it, and unmap it
+    void write_to_buffer(buffer const& buffer, void const* data, size_t size, size_t offset_in_buffer = 0);
 
+    /// map a readback buffer, memcpy its contents to the provided location, and unmap it
+    void read_from_buffer(buffer const& buffer, void* out_data, size_t size, size_t offset_in_buffer = 0);
+
+    /// map an upload buffer, memcpy the provided data into it, and unmap it
     template <class T>
-    void write_buffer_t(buffer const& buffer, T const& data)
+    void write_to_buffer_t(buffer const& buffer, T const& data, size_t offset_in_buffer = 0)
     {
-        static_assert(!std::is_pointer_v<T>, "[pr::Context::write_buffer_t] Pointer instead of raw data provided");
-        static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::write_buffer_t] Non-trivially copyable data provided");
-        write_buffer(buffer, &data, sizeof(T));
+        static_assert(!std::is_pointer_v<T>, "[pr::Context::write_to_buffer_t] Pointer instead of raw data provided");
+        static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::write_to_buffer_t] Non-trivially copyable data provided");
+        write_to_buffer(buffer, &data, sizeof(T), offset_in_buffer);
+    }
+
+    /// map a readback buffer, memcpy its contents to the provided location, and unmap it
+    template <class T>
+    void read_from_buffer_t(buffer const& buffer, T& out_data, size_t offset_in_buffer = 0)
+    {
+        static_assert(!std::is_pointer_v<T>, "[pr::Context::read_from_buffer_t] Pointer instead of raw data provided");
+        static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::read_from_buffer_t] Non-trivially copyable data provided");
+        read_from_buffer(buffer, &out_data, sizeof(T), offset_in_buffer);
     }
 
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -51,11 +51,15 @@ public:
     [[nodiscard]] auto_texture make_texture_array(int width, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
     /// create a 2D texture array
     [[nodiscard]] auto_texture make_texture_array(tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
+    /// create a texture from an info struct
+    [[nodiscard]] auto_texture make_texture(texture_info const& info);
 
     /// create a render target
     [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
     /// create a render target with an optimized clear value
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value const& optimized_clear);
+    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
+    /// create a render target from an info struct
+    [[nodiscard]] auto_render_target make_target(render_target_info const& info);
 
     /// create a buffer
     [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
@@ -65,6 +69,9 @@ public:
     [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1);
     /// create a mapped readback buffer which can be directly read from CPU
     [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0);
+    /// create a buffer from an info struct
+    [[nodiscard]] auto_buffer make_buffer(buffer_info const& info);
+
 
     /// create a shader from binary data
     [[nodiscard]] auto_shader_binary make_shader(std::byte const* data, size_t size, pr::shader stage);
@@ -87,26 +94,44 @@ public:
     // cache lookup API
     //
 
+    /// create or retrieve a render target from the cache
     [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+    [[nodiscard]] cached_render_target get_target(render_target_info const& info);
 
+    /// create or retrieve a buffer from the cache
     [[nodiscard]] cached_buffer get_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
     [[nodiscard]] cached_buffer get_upload_buffer(unsigned size, unsigned stride = 0);
     [[nodiscard]] cached_buffer get_readback_buffer(unsigned size, unsigned stride = 0);
+    [[nodiscard]] cached_buffer get_buffer(buffer_info const& info);
 
+    /// create or retrieve a texture from the cache
+    [[nodiscard]] cached_texture get_texture(texture_info const& info);
+
+
+    //
+    // untyped creation and cache lookup API
+    //
+
+    /// create a resource of undetermined type, without RAII management (use free_untyped)
+    [[nodiscard]] raw_resource make_untyped_unlocked(generic_resource_info const& info);
+
+    /// create or retrieve a resource of undetermined type from cache, without RAII management (use free_to_cache_untyped)
+    [[nodiscard]] raw_resource get_untyped_unlocked(generic_resource_info const& info);
 
     //
     // freeing API
     //
 
     /// free a resource that was unlocked from automatic management
-    void free(raw_resource const& resource);
+    void free_untyped(phi::handle::resource resource);
+    void free_untyped(raw_resource const& resource) { free_untyped(resource.handle); }
 
     /// free a buffer
-    void free(buffer const& buffer) { free(buffer.res); }
+    void free(buffer const& buffer) { free_untyped(buffer.res); }
     /// free a texture
-    void free(texture const& texture) { free(texture.res); }
+    void free(texture const& texture) { free_untyped(texture.res); }
     /// free a render_target
-    void free(render_target const& rt) { free(rt.res); }
+    void free(render_target const& rt) { free_untyped(rt.res); }
 
     void free(graphics_pipeline_state const& pso) { freePipelineState(pso._handle); }
     void free(compute_pipeline_state const& pso) { freePipelineState(pso._handle); }
@@ -117,6 +142,8 @@ public:
             freeShaderBinary(shader._owning_blob);
     }
 
+    /// free a resource of undetermined type by placing it in the cache for reuse
+    void free_to_cache_untyped(raw_resource const& resource, generic_resource_info const& info);
     /// free a buffer by placing it in the cache for reuse
     void free_to_cache(buffer const& buffer);
     /// free a texture by placing it in the cache for reuse
@@ -125,8 +152,12 @@ public:
     void free_to_cache(render_target const& rt);
 
     //
-    // map upload API
+    // buffer map API
     //
+
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
+
+    void unmap_buffer(buffer const& buffer);
 
     void write_buffer(buffer const& buffer, void const* data, size_t size, size_t offset = 0);
 
@@ -137,10 +168,6 @@ public:
         static_assert(std::is_trivially_copyable_v<T>, "[pr::Context::write_buffer_t] Non-trivially copyable data provided");
         write_buffer(buffer, &data, sizeof(T));
     }
-
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
-
-    void unmap_buffer(buffer const& buffer);
 
     //
     // consumption API
@@ -186,11 +213,34 @@ public:
 
     /// frees all shader_views from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    unsigned clear_shader_view_cache();
+    [[deprecated("unimplemented")]] unsigned clear_shader_view_cache();
 
     /// frees all pipeline_states from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    unsigned clear_pipeline_state_cache();
+    [[deprecated("unimplemented")]] unsigned clear_pipeline_state_cache();
+
+    //
+    // phi interop
+    //
+
+    /// resource must have an assigned GUID if they are meant to interoperate with pr's caching mechanisms
+    /// use this method to "import" a raw phi resource
+    [[nodiscard]] raw_resource import_phi_resource(phi::handle::resource raw_resource) { return {raw_resource, acquireGuid()}; }
+
+    [[nodiscard]] buffer import_phi_buffer(phi::handle::resource raw_resource, buffer_info const& info)
+    {
+        return {import_phi_resource(raw_resource), info};
+    }
+
+    [[nodiscard]] render_target import_phi_target(phi::handle::resource raw_resource, render_target_info const& info)
+    {
+        return {import_phi_resource(raw_resource), info};
+    }
+
+    [[nodiscard]] texture import_phi_texture(phi::handle::resource raw_resource, texture_info const& info)
+    {
+        return {import_phi_resource(raw_resource), info};
+    }
 
     //
     // info
@@ -262,7 +312,7 @@ private:
     void internalInitialize();
 
     // creation
-    render_target createRenderTarget(render_target_info const& info, phi::rt_clear_value const* optimized_clear = nullptr);
+    render_target createRenderTarget(render_target_info const& info);
     texture createTexture(texture_info const& info);
     buffer createBuffer(buffer_info const& info);
 

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -33,7 +33,7 @@ raii::ComputePass raii::Frame::make_pass(const compute_pass_info& cp) & { return
 
 void raii::Frame::transition(const buffer& res, phi::resource_state target, phi::shader_stage_flags_t dependency)
 {
-    if (res.info.heap != phi::resource_heap::gpu) // mapped buffers are never transitioned
+    if (res.info.heap != resource_heap::gpu) // mapped buffers are never transitioned
         return;
 
     transition(res.res.handle, target, dependency);
@@ -114,6 +114,7 @@ void raii::Frame::upload_texture_data(std::byte const* texture_data, const buffe
     transition(dest_texture, phi::resource_state::copy_dest);
     flushPendingTransitions();
     CC_ASSERT(dest_texture.info.depth_or_array_size == 1 && "array upload unimplemented");
+    CC_ASSERT(upload_buffer.info.heap == resource_heap::upload && "buffer is not an upload buffer");
 
     auto const bytes_per_pixel = phi::detail::format_size_bytes(dest_texture.info.fmt);
     auto const use_d3d12_per_row_alingment = mCtx->get_backend().getBackendType() == phi::backend_type::d3d12;

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -164,7 +164,11 @@ public:
 
 private:
     friend class Frame;
-    framebuffer_builder(Frame* parent) : _parent(parent) { _cmd.viewport = {1 << 30, 1 << 30}; }
+    framebuffer_builder(Frame* parent) : _parent(parent)
+    {
+        _cmd.viewport = {1 << 30, 1 << 30};
+        _cmd.set_null_depth_stencil();
+    }
 
     void adjust_config(render_target const& rt)
     {

--- a/src/phantasm-renderer/common/log.hh
+++ b/src/phantasm-renderer/common/log.hh
@@ -2,7 +2,32 @@
 
 #include <rich-log/log.hh>
 
-namespace pr
+namespace pr::detail
 {
-constexpr void logger(rlog::MessageBuilder& builder) { builder.set_domain(rlog::domain("PR")); }
+static constexpr rlog::domain domain = rlog::domain("PR");
+static constexpr rlog::severity assert_severity = rlog::severity("ASSERT", "\u001b[38;5;196m\u001b[1m");
+
+constexpr void info_log(rlog::MessageBuilder& builder) { builder.set_domain(domain); }
+constexpr void warn_log(rlog::MessageBuilder& builder)
+{
+    builder.set_domain(domain);
+    builder.set_severity(rlog::severity::warning());
+    builder.set_use_error_stream(true);
 }
+constexpr void err_log(rlog::MessageBuilder& builder)
+{
+    builder.set_domain(domain);
+    builder.set_severity(rlog::severity::error());
+    builder.set_use_error_stream(true);
+}
+constexpr void assert_log(rlog::MessageBuilder& builder)
+{
+    builder.set_domain(domain);
+    builder.set_severity(assert_severity);
+    builder.set_use_error_stream(true);
+}
+}
+
+#define PR_LOG RICH_LOG_IMPL(pr::detail::info_log)
+#define PR_LOG_WARN RICH_LOG_IMPL(pr::detail::warn_log)
+#define PR_LOG_ERROR RICH_LOG_IMPL(pr::detail::err_log)

--- a/src/phantasm-renderer/common/log.hh
+++ b/src/phantasm-renderer/common/log.hh
@@ -4,5 +4,5 @@
 
 namespace pr
 {
-constexpr void pr_log(rlog::MessageBuilder& builder) { builder.set_domain(rlog::domain("PR")); }
+constexpr void logger(rlog::MessageBuilder& builder) { builder.set_domain(rlog::domain("PR")); }
 }

--- a/src/phantasm-renderer/common/log.hh
+++ b/src/phantasm-renderer/common/log.hh
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <rich-log/log.hh>
+
+namespace pr
+{
+constexpr void pr_log(rlog::MessageBuilder& builder) { builder.set_domain(rlog::domain("PR")); }
+}

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -2,19 +2,24 @@
 
 #include <clean-core/hash.hh>
 
+#include <typed-geometry/types/size.hh>
+
 #include <phantasm-hardware-interface/arguments.hh>
+
+#include <phantasm-renderer/enums.hh>
 
 namespace pr
 {
 using render_target_info = phi::arg::create_render_target_info;
 using texture_info = phi::arg::create_texture_info;
 using buffer_info = phi::arg::create_buffer_info;
+using generic_resource_info = phi::arg::create_resource_info;
 
 struct resource_info_hasher
 {
     constexpr size_t operator()(render_target_info const& rt) const noexcept
     {
-        return cc::make_hash(rt.format, rt.width, rt.height, rt.num_samples, rt.array_size);
+        return cc::make_hash(rt.format, rt.width, rt.height, rt.num_samples, rt.array_size, rt.clear_value);
     }
 
     constexpr size_t operator()(texture_info const& t) const noexcept

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -39,21 +39,14 @@ struct texture_info
 
 struct buffer_info
 {
-    enum map_type : uint8_t
-    {
-        unmapped = 0,
-        mapped_upload,
-        mapped_readback
-    };
-
     unsigned size_bytes;
     unsigned stride_bytes;
     bool allow_uav;
-    map_type map;
+    phi::resource_heap heap;
 
     constexpr bool operator==(buffer_info const& rhs) const noexcept
     {
-        return size_bytes == rhs.size_bytes && stride_bytes == rhs.stride_bytes && allow_uav == rhs.allow_uav && map == rhs.map;
+        return size_bytes == rhs.size_bytes && stride_bytes == rhs.stride_bytes && allow_uav == rhs.allow_uav && heap == rhs.heap;
     }
 };
 
@@ -69,6 +62,6 @@ struct resource_info_hasher
         return cc::make_hash(t.fmt, t.dim, t.allow_uav, t.width, t.height, t.depth_or_array_size, t.num_mips);
     }
 
-    constexpr size_t operator()(buffer_info const& b) const noexcept { return cc::make_hash(b.size_bytes, b.stride_bytes, b.allow_uav, b.map); }
+    constexpr size_t operator()(buffer_info const& b) const noexcept { return cc::make_hash(b.size_bytes, b.stride_bytes, b.allow_uav, b.heap); }
 };
 }

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -2,53 +2,13 @@
 
 #include <clean-core/hash.hh>
 
-#include <phantasm-hardware-interface/types.hh>
+#include <phantasm-hardware-interface/arguments.hh>
 
 namespace pr
 {
-struct render_target_info
-{
-    phi::format format;
-    int width;
-    int height;
-    unsigned num_samples;
-    unsigned array_size;
-
-    constexpr bool operator==(render_target_info const& rhs) const noexcept
-    {
-        return format == rhs.format && width == rhs.width && height == rhs.height && num_samples == rhs.num_samples && array_size == rhs.array_size;
-    }
-};
-
-struct texture_info
-{
-    phi::format fmt;
-    phi::texture_dimension dim;
-    bool allow_uav;
-    int width;
-    int height;
-    unsigned depth_or_array_size;
-    unsigned num_mips;
-
-    constexpr bool operator==(texture_info const& rhs) const noexcept
-    {
-        return fmt == rhs.fmt && dim == rhs.dim && allow_uav == rhs.allow_uav && width == rhs.width && height == rhs.height
-               && depth_or_array_size == rhs.depth_or_array_size && num_mips == rhs.num_mips;
-    }
-};
-
-struct buffer_info
-{
-    unsigned size_bytes;
-    unsigned stride_bytes;
-    bool allow_uav;
-    phi::resource_heap heap;
-
-    constexpr bool operator==(buffer_info const& rhs) const noexcept
-    {
-        return size_bytes == rhs.size_bytes && stride_bytes == rhs.stride_bytes && allow_uav == rhs.allow_uav && heap == rhs.heap;
-    }
-};
+using render_target_info = phi::arg::create_render_target_info;
+using texture_info = phi::arg::create_texture_info;
+using buffer_info = phi::arg::create_buffer_info;
 
 struct resource_info_hasher
 {

--- a/src/phantasm-renderer/detail/auto_destroyer.cc
+++ b/src/phantasm-renderer/detail/auto_destroyer.cc
@@ -8,11 +8,11 @@ void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::ren
 
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::texture& v) { ctx->free_to_cache(v); }
 
-void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::buffer& v) { ctx->free(v.res); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::buffer& v) { ctx->free_untyped(v.res); }
 
-void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::render_target& v) { ctx->free(v.res); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::render_target& v) { ctx->free_untyped(v.res); }
 
-void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::texture& v) { ctx->free(v.res); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::texture& v) { ctx->free_untyped(v.res); }
 
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pipeline_state_abstract& v) { ctx->freePipelineState(v._handle); }
 

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -19,11 +19,11 @@ using state = phi::resource_state;
 using phi::blend_factor;
 using phi::blend_logic_op;
 using phi::blend_op;
+using phi::resource_heap;
 using phi::sampler_address_mode;
 using phi::sampler_border_color;
 using phi::sampler_compare_func;
 using phi::sampler_filter;
-using phi::resource_heap;
 
 // struct passthroughs
 using phi::blend_state;

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -23,6 +23,7 @@ using phi::sampler_address_mode;
 using phi::sampler_border_color;
 using phi::sampler_compare_func;
 using phi::sampler_filter;
+using phi::resource_heap;
 
 // struct passthroughs
 using phi::blend_state;


### PR DESCRIPTION
- Adapt to phi changes regarding mapped buffers (breaking)
    - Add `Context::map_buffer`, `Context::unmap_buffer`
    - Remove `Context::get_buffer_map`, `Context::flush_buffer_writes`
    - In most cases, the two removed functions can be replaced by map/unmap (if used locally)
- Add extended phi interop API
    - Import an external `phi::handle::resource` by acquiring a GUID and filling in userprovided info
- Add untyped resource creation and cache lookup API
    - Add creation and cache-lookup of `render_target`, `buffer` and `texture` from info structs
    - Add creation and cache-lookup of "untyped" `pr::raw_resource` from `generic_resource_info`
    - Add matching free / free_to_cache
- Adapt to rich-log changes