### PR TITLE
Fences, Queries, Indirect Drawing, Fixes

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -2,7 +2,7 @@
 
 #include <clean-core/vector.hh>
 
-#include <phantasm-hardware-interface/types.hh>
+#include <phantasm-hardware-interface/handles.hh>
 
 #include <phantasm-renderer/common/state_info.hh>
 

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -235,7 +235,13 @@ void Context::unmap_buffer(const buffer& buffer) { mBackend->unmapBuffer(buffer.
 
 cached_render_target Context::get_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size)
 {
-    auto const info = render_target_info{format, size.width, size.height, num_samples, array_size};
+    auto const info = render_target_info::create(format, size.width, size.height, num_samples, array_size);
+    return {acquireRenderTarget(info), this};
+}
+
+cached_render_target Context::get_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear)
+{
+    auto const info = render_target_info::create(format, size.width, size.height, num_samples, array_size, optimized_clear);
     return {acquireRenderTarget(info), this};
 }
 

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -232,7 +232,7 @@ void Context::write_to_buffer_raw(const buffer& buffer, cc::span<std::byte const
 
 void Context::read_from_buffer_raw(const buffer& buffer, cc::span<std::byte> out_data, size_t offset_in_buffer)
 {
-    CC_ASSERT(buffer.info.heap == phi::resource_heap::upload && "Attempted to read from non-readback buffer");
+    CC_ASSERT(buffer.info.heap == phi::resource_heap::readback && "Attempted to read from non-readback buffer");
     CC_ASSERT(buffer.info.size_bytes >= out_data.size() + offset_in_buffer && "Buffer read out of bounds");
 
     auto* const map = map_buffer(buffer);

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -53,6 +53,8 @@ public:
     [[nodiscard]] auto_texture make_texture_array(tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
     /// create a texture from an info struct
     [[nodiscard]] auto_texture make_texture(texture_info const& info);
+    /// create a texture from the info of a different texture. NOTE: does not concern contents or state
+    [[nodiscard]] auto_texture make_texture_clone(texture const& clone_source) { return make_texture(clone_source.info); }
 
     /// create a render target
     [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
@@ -60,6 +62,8 @@ public:
     [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
     /// create a render target from an info struct
     [[nodiscard]] auto_render_target make_target(render_target_info const& info);
+    /// create a render target from the info of a different one. NOTE: does not concern contents or state
+    [[nodiscard]] auto_render_target make_target_clone(render_target const& clone_source) { return make_target(clone_source.info); }
 
     /// create a buffer
     [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
@@ -71,6 +75,8 @@ public:
     [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0);
     /// create a buffer from an info struct
     [[nodiscard]] auto_buffer make_buffer(buffer_info const& info);
+    /// create a buffer from the info of a different buffer. NOTE: does not concern contents or state
+    [[nodiscard]] auto_buffer make_buffer_clone(buffer const& clone_source) { return make_buffer(clone_source.info); }
 
 
     /// create a shader from binary data

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -356,18 +356,18 @@ private:
     // single cache access, Frame-side API
 private:
     friend class raii::Frame;
-    phi::handle::pipeline_state acquire_graphics_pso(murmur_hash hash, const graphics_pass_info& gp, const framebuffer_info& fb);
-    phi::handle::pipeline_state acquire_compute_pso(murmur_hash hash, const compute_pass_info& cp);
+    phi::handle::pipeline_state acquire_graphics_pso(cc::hash_t hash, const graphics_pass_info& gp, const framebuffer_info& fb);
+    phi::handle::pipeline_state acquire_compute_pso(cc::hash_t hash, const compute_pass_info& cp);
 
-    phi::handle::shader_view acquire_graphics_sv(murmur_hash hash, hashable_storage<shader_view_info> const& info_storage);
-    phi::handle::shader_view acquire_compute_sv(murmur_hash hash, hashable_storage<shader_view_info> const& info_storage);
+    phi::handle::shader_view acquire_graphics_sv(cc::hash_t hash, hashable_storage<shader_view_info> const& info_storage);
+    phi::handle::shader_view acquire_compute_sv(cc::hash_t hash, hashable_storage<shader_view_info> const& info_storage);
 
     void free_all(cc::span<freeable_cached_obj const> freeables);
 
-    void free_graphics_pso(murmur_hash hash);
-    void free_compute_pso(murmur_hash hash);
-    void free_graphics_sv(murmur_hash hash);
-    void free_compute_sv(murmur_hash hash);
+    void free_graphics_pso(cc::hash_t hash);
+    void free_compute_pso(cc::hash_t hash);
+    void free_graphics_sv(cc::hash_t hash);
+    void free_compute_sv(cc::hash_t hash);
 
     // members
 private:

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -102,6 +102,9 @@ public:
 
     /// create or retrieve a render target from the cache
     [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+    /// create or retrieve a render target with an optimized clear value from the cache
+    [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
+    /// create or retrieve a render target from an info struct from the cache
     [[nodiscard]] cached_render_target get_target(render_target_info const& info);
 
     /// create or retrieve a buffer from the cache

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -1,7 +1,7 @@
 #include "Frame.hh"
 
-#include <clean-core/utility.hh>
 #include <clean-core/hash_combine.hh>
+#include <clean-core/utility.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/detail/byte_util.hh>
@@ -40,15 +40,9 @@ void raii::Frame::transition(const buffer& res, pr::state target, shader_flags d
     transition(res.res.handle, target, dependency);
 }
 
-void raii::Frame::transition(const texture& res, pr::state target, shader_flags dependency)
-{
-    transition(res.res.handle, target, dependency);
-}
+void raii::Frame::transition(const texture& res, pr::state target, shader_flags dependency) { transition(res.res.handle, target, dependency); }
 
-void raii::Frame::transition(const render_target& res, pr::state target, shader_flags dependency)
-{
-    transition(res.res.handle, target, dependency);
-}
+void raii::Frame::transition(const render_target& res, pr::state target, shader_flags dependency) { transition(res.res.handle, target, dependency); }
 
 void raii::Frame::transition(phi::handle::resource raw_resource, pr::state target, shader_flags dependency)
 {
@@ -58,14 +52,14 @@ void raii::Frame::transition(phi::handle::resource raw_resource, pr::state targe
     mPendingTransitionCommand.add(raw_resource, target, dependency);
 }
 
-void raii::Frame::copy(const buffer& src, const buffer& dest, size_t src_offset, size_t dest_offset)
+void raii::Frame::copy(const buffer& src, const buffer& dest, size_t src_offset, size_t dest_offset, size_t num_bytes)
 {
     transition(src, pr::state::copy_src);
     transition(dest, pr::state::copy_dest);
     flushPendingTransitions();
 
     phi::cmd::copy_buffer ccmd;
-    ccmd.init(src.res.handle, dest.res.handle, cc::min(src.info.size_bytes, dest.info.size_bytes), src_offset, dest_offset);
+    ccmd.init(src.res.handle, dest.res.handle, num_bytes > 0 ? num_bytes : cc::min(src.info.size_bytes, dest.info.size_bytes), src_offset, dest_offset);
     mWriter.add_command(ccmd);
 }
 

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -1,6 +1,7 @@
 #include "Frame.hh"
 
 #include <clean-core/utility.hh>
+#include <clean-core/hash_combine.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/detail/byte_util.hh>
@@ -302,8 +303,7 @@ phi::handle::pipeline_state raii::Frame::framebufferAcquireGraphicsPSO(const gra
 {
     CC_ASSERT(fb_inferred_num_samples == -1
               || fb_inferred_num_samples == gp._storage.get().graphics_config.samples && "graphics_pass_info has incorrect amount of samples configured");
-    auto const gp_hash = gp.get_hash();
-    auto const combined_hash = gp_hash.combine(fb.get_hash());
+    auto const combined_hash = cc::hash_combine(gp.get_hash(), fb.get_hash());
     auto const res = mCtx->acquire_graphics_pso(combined_hash, gp, fb);
     mFreeables.push_back({freeable_cached_obj::graphics_pso, combined_hash});
     return res;
@@ -319,8 +319,7 @@ void raii::Frame::passOnDispatch(const phi::cmd::dispatch& dcmd)
 
 phi::handle::shader_view raii::Frame::passAcquireGraphicsShaderView(const argument& arg)
 {
-    murmur_hash hash;
-    arg._info.get_murmur(hash);
+    auto const hash = arg._info.get_xxhash();
     auto const res = mCtx->acquire_graphics_sv(hash, arg._info);
     mFreeables.push_back({freeable_cached_obj::graphics_sv, hash});
     return res;
@@ -328,8 +327,7 @@ phi::handle::shader_view raii::Frame::passAcquireGraphicsShaderView(const argume
 
 phi::handle::shader_view raii::Frame::passAcquireComputeShaderView(const argument& arg)
 {
-    murmur_hash hash;
-    arg._info.get_murmur(hash);
+    auto const hash = arg._info.get_xxhash();
     auto const res = mCtx->acquire_compute_sv(hash, arg._info);
     mFreeables.push_back({freeable_cached_obj::compute_sv, hash});
     return res;

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -81,7 +81,7 @@ public:
     //
     // commands
 
-    void copy(buffer const& src, buffer const& dest, size_t src_offset = 0, size_t dest_offset = 0);
+    void copy(buffer const& src, buffer const& dest, size_t src_offset = 0, size_t dest_offset = 0, size_t num_bytes = 0);
     void copy(buffer const& src, texture const& dest, size_t src_offset = 0, unsigned dest_mip_index = 0, unsigned dest_array_index = 0);
 
     void copy(texture const& src, texture const& dest);

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -65,16 +65,16 @@ public:
     //
     // transitions and present
 
-    void transition(buffer const& res, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
-    void transition(texture const& res, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
-    void transition(render_target const& res, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
-    void transition(phi::handle::resource raw_resource, phi::resource_state target, phi::shader_stage_flags_t dependency = {});
+    void transition(buffer const& res, state target, shader_flags dependency = {});
+    void transition(texture const& res, state target, shader_flags dependency = {});
+    void transition(render_target const& res, state target, shader_flags dependency = {});
+    void transition(phi::handle::resource raw_resource, state target, shader_flags dependency = {});
 
     /// transition the backbuffer to present state and trigger a Context::present after this frame is submitted
     void present_after_submit(render_target const& backbuffer)
     {
         CC_ASSERT(!mPresentAfterSubmitRequested && "only one present_after_submit per pr::raii::Frame allowed");
-        transition(backbuffer, phi::resource_state::present);
+        transition(backbuffer, state::present);
         mPresentAfterSubmitRequested = true;
     }
 
@@ -132,7 +132,7 @@ public:
     /// write multiple resource slice transitions - no state tracking
     void transition_slices(cc::span<phi::cmd::transition_image_slices::slice_transition_info const> slices);
 
-    pr::Context& context() { return *mCtx; }
+    Context& context() { return *mCtx; }
 
 public:
     // redirect intuitive misuses

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -93,6 +93,12 @@ public:
     void resolve(render_target const& src, texture const& dest);
     void resolve(render_target const& src, render_target const& dest);
 
+    /// write a timestamp to a query in a given (timestamp) query range
+    void write_timestamp(query_range const& query_range, unsigned index);
+
+    /// resolve one or more queries in a range and write their contents to a buffer
+    void resolve_queries(query_range const& src, buffer const& dest, unsigned first_query, unsigned num_queries, unsigned dest_offset_bytes = 0);
+
     /// begin a debug label region (visible in renderdoc, nsight, gpa, pix, etc.)
     void begin_debug_label(char const* label) { write_raw_cmd(phi::cmd::begin_debug_label{label}); }
     void end_debug_label() { write_raw_cmd(phi::cmd::end_debug_label{}); }

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -15,6 +15,7 @@ void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer)
 void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer)
 {
     CC_ASSERT(index_buffer.info.stride_bytes > 0 && "index buffer not strided");
+    CC_ASSERT(index_buffer.info.stride_bytes <= 4 && "index buffer stride unusually large - switched up vertex and index buffer?");
     draw(vertex_buffer.res.handle, index_buffer.res.handle, index_buffer.info.size_bytes / index_buffer.info.stride_bytes);
 }
 

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -29,6 +29,21 @@ void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::hand
     mParent->passOnDraw(mCmd);
 }
 
+void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, const pr::buffer& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset)
+{
+    phi::cmd::draw_indirect dcmd;
+    std::memcpy(dcmd.root_constants, mCmd.root_constants, sizeof(dcmd.root_constants));
+    std::memcpy(dcmd.shader_arguments.data(), mCmd.shader_arguments.data(), sizeof(dcmd.shader_arguments));
+    dcmd.pipeline_state = mCmd.pipeline_state;
+    dcmd.indirect_argument_buffer = argument_buffer.res.handle;
+    dcmd.argument_buffer_offset = arg_buffer_offset;
+    dcmd.num_arguments = num_args;
+    dcmd.vertex_buffer = vertex_buffer.res.handle;
+    dcmd.index_buffer = phi::handle::null_resource;
+
+    mParent->write_raw_cmd(dcmd);
+}
+
 void pr::raii::GraphicsPass::add_argument(const pr::argument& arg)
 {
     ++mArgNum;

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -26,6 +26,8 @@ public:
     void draw(buffer const& vertex_buffer, buffer const& index_buffer);
     void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices);
 
+    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset = 0);
+
     void set_offset(unsigned vertex_offset, unsigned index_offset = 0);
 
     void set_scissor(tg::iaabb2 scissor) { mCmd.scissor = scissor; }

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -79,6 +79,14 @@ struct resource_view_info
     return res;
 }
 
+[[nodiscard]] inline resource_view_info resource_view_structured_buffer(buffer const& buf, unsigned num_elems, unsigned stride_bytes, unsigned first_element = 0)
+{
+    resource_view_info res;
+    res.guid = buf.res.guid;
+    res.rv.init_as_structured_buffer(buf.res.handle, num_elems, stride_bytes, first_element);
+    return res;
+}
+
 // fixed size, hashable, no raw resources allowed
 struct argument
 {

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -4,6 +4,7 @@
 
 #include <clean-core/new.hh>
 #include <clean-core/storage.hh>
+#include <clean-core/xxHash.hh>
 
 #include "murmur_hash.hh"
 
@@ -40,6 +41,9 @@ public:
 
     // with the established guarantees, hashing and comparison are trivial
     void get_murmur(murmur_hash& out) const { murmurhash3_x64_128(&_storage.value, sizeof(T), 0, out); }
+
+    cc::hash_t get_xxhash() const { return cc::hash_xxh3(cc::as_byte_span(_storage.value), 0); }
+
     bool operator==(hashable_storage<T> const& rhs) const noexcept { return std::memcmp(&_storage.value, &rhs._storage.value, sizeof(T)) == 0; }
 
 private:

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -2,11 +2,7 @@
 
 #include <clean-core/hash.hh>
 
-#include <typed-geometry/types/size.hh>
-
 #include <phantasm-hardware-interface/arguments.hh>
-
-#include <phantasm-renderer/enums.hh>
 
 namespace pr
 {

--- a/src/phantasm-renderer/common/single_cache.hh
+++ b/src/phantasm-renderer/common/single_cache.hh
@@ -3,12 +3,12 @@
 #include <mutex>
 
 #include <clean-core/map.hh>
+#include <clean-core/typedefs.hh>
 
 #include <rich-log/log.hh>
 
 #include <phantasm-hardware-interface/types.hh>
 
-#include <phantasm-renderer/common/murmur_hash.hh>
 #include <phantasm-renderer/fwd.hh>
 
 namespace pr
@@ -26,7 +26,7 @@ private:
 public:
     void reserve(size_t num_elems) { _map.reserve(num_elems); }
 
-    [[nodiscard]] ValT acquire(murmur_hash key)
+    [[nodiscard]] ValT acquire(cc::hash_t key)
     {
         auto lg = std::lock_guard(_mutex);
         map_element& elem = _map[key];
@@ -38,7 +38,7 @@ public:
         return elem.val;
     }
 
-    void insert(ValT val, murmur_hash key)
+    void insert(ValT val, cc::hash_t key)
     {
         auto lg = std::lock_guard(_mutex);
         CC_ASSERT(val != invalid_val && "[single_cache] invalid value inserted");
@@ -48,7 +48,7 @@ public:
         elem.required_gpu_epoch = 0;
     }
 
-    void free(murmur_hash key, gpu_epoch_t current_cpu_epoch)
+    void free(cc::hash_t key, gpu_epoch_t current_cpu_epoch)
     {
         auto lg = std::lock_guard(_mutex);
         map_element& elem = _map[key];
@@ -92,7 +92,7 @@ private:
         gpu_epoch_t required_gpu_epoch = 0; ///< CPU epoch when this element was last freed
     };
 
-    cc::map<murmur_hash, map_element, murmur_collapser> _map;
+    cc::map<cc::hash_t, map_element> _map;
     std::mutex _mutex;
 };
 }

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <clean-core/typedefs.hh>
+
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/detail/trivial_capped_vector.hh>
 #include <phantasm-hardware-interface/types.hh>
-
-#include <phantasm-renderer/common/murmur_hash.hh>
 
 
 namespace pr
@@ -20,7 +20,7 @@ struct freeable_cached_obj
     };
 
     type type;
-    murmur_hash hash;
+    cc::hash_t hash;
 };
 
 // for economic reasons, SRVs, UAVs and Samplers are limited for cache-access shader views
@@ -40,13 +40,13 @@ struct graphics_pass_info_data
     bool has_root_consts = false;
     phi::detail::trivial_capped_vector<phi::vertex_attribute_info, 8> vertex_attributes;
     phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
-    phi::detail::trivial_capped_vector<murmur_hash, 5> shader_hashes;
+    phi::detail::trivial_capped_vector<cc::hash_t, 5> shader_hashes;
 };
 
 struct compute_pass_info_data
 {
     bool has_root_consts = false;
     phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
-    murmur_hash shader_hash;
+    cc::hash_t shader_hash;
 };
 }

--- a/src/phantasm-renderer/detail/auto_destroyer.cc
+++ b/src/phantasm-renderer/detail/auto_destroyer.cc
@@ -1,27 +1,18 @@
 #include "auto_destroyer.hh"
 
+#include <phantasm-hardware-interface/Backend.hh>
+
 #include <phantasm-renderer/Context.hh>
 
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::buffer& v) { ctx->free_to_cache(v); }
-
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::render_target& v) { ctx->free_to_cache(v); }
-
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::texture& v) { ctx->free_to_cache(v); }
 
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::buffer& v) { ctx->free_untyped(v.res); }
-
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::render_target& v) { ctx->free_untyped(v.res); }
-
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::texture& v) { ctx->free_untyped(v.res); }
-
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pipeline_state_abstract& v) { ctx->freePipelineState(v._handle); }
-
-void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::shader_binary& v)
-{
-    if (v._owning_blob != nullptr)
-    {
-        ctx->freeShaderBinary(v._owning_blob);
-    }
-}
-
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::shader_binary& v) { ctx->free(v); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::prebuilt_argument& v) { ctx->freeShaderView(v._sv); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::fence& v) { ctx->free(v); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::query_range& v) { ctx->free(v); }

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -13,12 +13,15 @@ struct auto_destroy_proxy
     static void cache_deref(pr::Context* ctx, buffer const& v);
     static void cache_deref(pr::Context* ctx, render_target const& v);
     static void cache_deref(pr::Context* ctx, texture const& v);
+
     static void destroy(pr::Context* ctx, buffer const& v);
     static void destroy(pr::Context* ctx, render_target const& v);
     static void destroy(pr::Context* ctx, texture const& v);
     static void destroy(pr::Context* ctx, pipeline_state_abstract const& v);
     static void destroy(pr::Context* ctx, shader_binary const& v);
     static void destroy(pr::Context* ctx, prebuilt_argument const& v);
+    static void destroy(pr::Context* ctx, fence const& v);
+    static void destroy(pr::Context* ctx, query_range const& v);
 };
 }
 

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -30,6 +30,7 @@ using phi::sampler_filter;
 
 // type renames
 using shader_flags = phi::shader_stage_flags_t;
+using clear_value = phi::rt_clear_value;
 
 // type passthroughs
 using phi::blend_state;

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -28,7 +28,10 @@ using phi::sampler_border_color;
 using phi::sampler_compare_func;
 using phi::sampler_filter;
 
-// struct passthroughs
+// type renames
+using shader_flags = phi::shader_stage_flags_t;
+
+// type passthroughs
 using phi::blend_state;
 using phi::pipeline_config;
 using phi::sampler_config;

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -22,6 +22,8 @@ using phi::blend_op;
 using phi::cull_mode;
 using phi::depth_function;
 using phi::primitive_topology;
+using phi::query_type;
+using phi::queue_type;
 using phi::resource_heap;
 using phi::sampler_address_mode;
 using phi::sampler_border_color;

--- a/src/phantasm-renderer/fwd.hh
+++ b/src/phantasm-renderer/fwd.hh
@@ -39,14 +39,18 @@ struct graphics_pass_info;
 struct compute_pass_info;
 struct framebuffer_info;
 
-// shaders and pipeline states
+// shaders, PSOs, fences, query ranges
 struct shader_binary;
 struct pipeline_state_abstract;
 struct graphics_pipeline_state;
 struct compute_pipeline_state;
+struct fence;
+struct query_range;
 using auto_shader_binary = auto_destroyer<shader_binary, false>;
 using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, false>;
 using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
+using auto_fence = auto_destroyer<fence, false>;
+using auto_query_range = auto_destroyer<query_range, false>;
 
 // shader arguments
 struct argument;

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -107,12 +107,7 @@ public:
 
 private:
     friend class raii::Frame;
-    [[nodiscard]] murmur_hash get_hash() const
-    {
-        murmur_hash res;
-        _storage.get_murmur(res);
-        return res;
-    }
+    cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
 private:
     friend class Context;
@@ -153,12 +148,7 @@ public:
 
 private:
     friend class raii::Frame;
-    [[nodiscard]] murmur_hash get_hash() const
-    {
-        murmur_hash res;
-        _storage.get_murmur(res);
-        return res;
-    }
+    [[nodiscard]] cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
 private:
     friend class Context;
@@ -235,12 +225,7 @@ public:
 
 private:
     friend class raii::Frame;
-    [[nodiscard]] murmur_hash get_hash() const
-    {
-        murmur_hash res;
-        _storage.get_murmur(res);
-        return res;
-    }
+    cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
 private:
     friend class Context;

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -201,8 +201,15 @@ public:
         return *this;
     }
 
+    /// Add a render target with blend state
+    framebuffer_info& target(pr::format format, pr::blend_state blend_state)
+    {
+        _storage.get().render_targets.push_back(phi::render_target_config{format, true, blend_state});
+        return *this;
+    }
+
     /// Add a render target with blend configuration
-    framebuffer_info& target(phi::render_target_config config)
+    [[deprecated("Use target(format, blend_state) overload")]] framebuffer_info& target(phi::render_target_config config)
     {
         _storage.get().render_targets.push_back(config);
         return *this;

--- a/src/phantasm-renderer/reflection/vertex_attributes.hh
+++ b/src/phantasm-renderer/reflection/vertex_attributes.hh
@@ -29,7 +29,7 @@ constexpr phi::format to_attribute_format()
         return af::rgb32f;
     else if constexpr (tg::is_comp_like<T, 2, cc::float32>)
         return af::rg32f;
-    else if constexpr (tg::is_comp_like<T, 1, cc::float32>)
+    else if constexpr (std::is_same_v<T, cc::float32>)
         return af::r32f;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::int32>)
@@ -38,7 +38,7 @@ constexpr phi::format to_attribute_format()
         return af::rgb32i;
     else if constexpr (tg::is_comp_like<T, 2, cc::int32>)
         return af::rg32i;
-    else if constexpr (tg::is_comp_like<T, 1, cc::int32>)
+    else if constexpr (std::is_same_v<T, cc::int32>)
         return af::r32i;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::uint32>)
@@ -47,35 +47,35 @@ constexpr phi::format to_attribute_format()
         return af::rgb32u;
     else if constexpr (tg::is_comp_like<T, 2, cc::uint32>)
         return af::rg32u;
-    else if constexpr (tg::is_comp_like<T, 1, cc::uint32>)
+    else if constexpr (std::is_same_v<T, cc::uint32>)
         return af::r32u;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::int16>)
         return af::rgba16i;
     else if constexpr (tg::is_comp_like<T, 2, cc::int16>)
         return af::rg16i;
-    else if constexpr (tg::is_comp_like<T, 1, cc::int16>)
+    else if constexpr (std::is_same_v<T, cc::int16>)
         return af::r16i;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::uint16>)
         return af::rgba16u;
     else if constexpr (tg::is_comp_like<T, 2, cc::uint16>)
         return af::rg16u;
-    else if constexpr (tg::is_comp_like<T, 1, cc::uint16>)
+    else if constexpr (std::is_same_v<T, cc::uint16>)
         return af::r16u;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::int8>)
         return af::rgba8i;
     else if constexpr (tg::is_comp_like<T, 2, cc::int8>)
         return af::rg8i;
-    else if constexpr (tg::is_comp_like<T, 1, cc::int8>)
+    else if constexpr (std::is_same_v<T, cc::int8>)
         return af::r8i;
 
     else if constexpr (tg::is_comp_like<T, 4, cc::uint8>)
         return af::rgba8u;
     else if constexpr (tg::is_comp_like<T, 2, cc::uint8>)
         return af::rg8u;
-    else if constexpr (tg::is_comp_like<T, 1, cc::uint8>)
+    else if constexpr (std::is_same_v<T, cc::uint8>)
         return af::r8u;
 
     else

--- a/src/phantasm-renderer/resource_types.cc
+++ b/src/phantasm-renderer/resource_types.cc
@@ -1,3 +1,0 @@
-#include "resource_types.hh"
-
-#include "Context.hh"

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -5,7 +5,6 @@
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
 
-#include <phantasm-renderer/common/murmur_hash.hh>
 #include <phantasm-renderer/common/resource_info.hh>
 
 #include <phantasm-renderer/detail/auto_destroyer.hh>
@@ -53,7 +52,7 @@ struct shader_binary
     std::byte const* _data = nullptr;
     size_t _size = 0;
     IDxcBlob* _owning_blob = nullptr; ///< if non-null, shader was compiled online and must be freed via dxc
-    murmur_hash _hash;                ///< murmur hash over _data, for caching of PSOs using this shader
+    cc::hash_t _hash;                 ///< xxhash64 over _data, for caching of PSOs using this shader
     phi::shader_stage _stage;
 };
 

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <phantasm-hardware-interface/types.hh>
+#include <typed-geometry/types/size.hh>
 
-#include <phantasm-renderer/enums.hh>
-#include <phantasm-renderer/fwd.hh>
+#include <phantasm-hardware-interface/handles.hh>
 
 #include <phantasm-renderer/common/resource_info.hh>
-
 #include <phantasm-renderer/detail/auto_destroyer.hh>
+#include <phantasm-renderer/enums.hh>
 
-#include <typed-geometry/tg-lean.hh>
 
 namespace pr
 {
@@ -72,6 +70,21 @@ struct compute_pipeline_state : public pipeline_state_abstract
 };
 
 //
+// auxilliary
+
+struct fence
+{
+    phi::handle::fence handle = phi::handle::null_fence;
+};
+
+struct query_range
+{
+    phi::handle::query_range handle = phi::handle::null_query_range;
+    pr::query_type type;
+    unsigned num;
+};
+
+//
 // auto_ and cached_ aliases
 
 // move-only, self-destructing versions
@@ -82,6 +95,8 @@ using auto_texture = auto_destroyer<texture, false>;
 using auto_shader_binary = auto_destroyer<shader_binary, false>;
 using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, false>;
 using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
+using auto_fence = auto_destroyer<fence, false>;
+using auto_query_range = auto_destroyer<query_range, false>;
 
 // move-only, self-cachefreeing versions
 using cached_buffer = auto_destroyer<buffer, true>;


### PR DESCRIPTION
## Major
- Add fences
- Add query ranges
- Add make_*_clone Context methods
- Add write_timestamp and resolve_queries Frame methods
- Add draw_indirect Frame method

## Minor
- Add RT cache lookup with clear value
- Use xxHash over murmur hash internally
- Add gpu timestamp frequency getter, millisecond delta calculation util to Context
- Add num_bytes argument to buffer copy
- Use pr enum versions in more places
- Add assert to prevent mixing up vertex and index buffer
- Improve framebuffer info method for adding targets with blendstate config

## Fixes
- Fix readback buffer reading
- Fix RT cache lookup
- Fix vertex attribute reflection for primitive members (just a single float, int, etc.)