### PR TITLE
More texture copy overloads, advanced API

### DIFF
--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -438,6 +438,14 @@ unsigned Context::calculate_texture_upload_size(tg::isize3 size, phi::format fmt
     return res_bytes;
 }
 
+unsigned Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const
+{
+    CC_ASSERT(pixel.x < size.width && pixel.y < size.height && "pixel out of bounds");
+    auto const bytes_per_pixel = phi::detail::format_size_bytes(fmt);
+    auto const row_width = phi::mem::align_up(bytes_per_pixel * size.width, 256);
+    return pixel.y * row_width + pixel.x * bytes_per_pixel;
+}
+
 render_target Context::acquire_backbuffer()
 {
     auto const backbuffer = mBackend->acquireBackbuffer();

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -403,7 +403,7 @@ bool Context::flush(gpu_epoch_t epoch)
 }
 
 bool Context::start_capture() { return mBackend->startForcedDiagnosticCapture(); }
-bool Context::end_capture() { return mBackend->endForcedDiagnosticCapture(); }
+bool Context::stop_capture() { return mBackend->endForcedDiagnosticCapture(); }
 
 void Context::on_window_resize(tg::isize2 size) { mBackend->onResize(size); }
 

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -321,7 +321,7 @@ public:
     /// attempts to start a capture in a connected tool like Renderdoc, PIX, NSight etc
     bool start_capture();
     /// ends a capture previously started with start_capture()
-    bool end_capture();
+    bool stop_capture();
 
     /// returns the underlying phantasm-hardware-interface backend
     phi::Backend& get_backend() { return *mBackend; }

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -318,10 +318,19 @@ public:
     // miscellaneous
     //
 
+    /// attempts to start a capture in a connected tool like Renderdoc, PIX, NSight etc
     bool start_capture();
+    /// ends a capture previously started with start_capture()
     bool end_capture();
 
+    /// returns the underlying phantasm-hardware-interface backend
     phi::Backend& get_backend() { return *mBackend; }
+
+    /// monotonously increasing uint64, always greater or equal to GPU epoch
+    gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker.get_current_epoch_cpu(); }
+
+    /// monotously increasing uint64, GPU timeline, always less or equal to CPU
+    gpu_epoch_t get_current_gpu_epoch() const { return mGpuEpochTracker.get_current_epoch_gpu(); }
 
 public:
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -307,11 +307,14 @@ public:
         return (double(end - start) / mGPUTimestampFrequency) * 1000.;
     }
 
-    /// returns the amount of bytes needed to store the contents of a texture in an upload buffer
+    /// returns the amount of bytes needed to store the contents of a texture (in a GPU buffer)
     unsigned calculate_texture_upload_size(tg::isize3 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(int width, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(texture const& texture, unsigned num_mips = 1) const;
+
+    /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
+    unsigned calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const;
 
 
     //
@@ -461,12 +464,12 @@ inline auto_buffer Context::make_upload_buffer_for_texture(const texture& tex, u
     return make_upload_buffer(calculate_texture_upload_size(tex, num_mips));
 }
 
-inline unsigned Context::calculate_texture_upload_size(tg::isize2 size, phi::format fmt, unsigned num_mips) const
+inline unsigned Context::calculate_texture_upload_size(tg::isize2 size, pr::format fmt, unsigned num_mips) const
 {
     return calculate_texture_upload_size({size.width, size.height, 1}, fmt, num_mips);
 }
 
-inline unsigned Context::calculate_texture_upload_size(int width, phi::format fmt, unsigned num_mips) const
+inline unsigned Context::calculate_texture_upload_size(int width, pr::format fmt, unsigned num_mips) const
 {
     return calculate_texture_upload_size({width, 1, 1}, fmt, num_mips);
 }

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -76,6 +76,17 @@ void raii::Frame::copy(const buffer& src, const texture& dest, size_t src_offset
     mWriter.add_command(ccmd);
 }
 
+void raii::Frame::copy(const render_target& src, const buffer& dest, size_t dest_offset)
+{
+    transition(src, pr::state::copy_src);
+    transition(dest, pr::state::copy_dest);
+    flushPendingTransitions();
+
+    phi::cmd::copy_texture_to_buffer ccmd;
+    ccmd.init(src.res.handle, dest.res.handle, src.info.width, src.info.height, dest_offset);
+    mWriter.add_command(ccmd);
+}
+
 void raii::Frame::copy(const texture& src, const texture& dest, unsigned mip_index)
 {
     CC_ASSERT(src.info.width == dest.info.width && "copy size mismatch");

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -199,6 +199,7 @@ private:
 private:
     friend class Framebuffer;
     void framebufferOnJoin(Framebuffer const&);
+    void framebufferOnSortByPSO(unsigned num_drawcalls);
 
     phi::handle::pipeline_state framebufferAcquireGraphicsPSO(pr::graphics_pass_info const& gp, pr::framebuffer_info const& fb, int fb_inferred_num_samples);
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -84,10 +84,24 @@ public:
     void copy(buffer const& src, buffer const& dest, size_t src_offset = 0, size_t dest_offset = 0, size_t num_bytes = 0);
     void copy(buffer const& src, texture const& dest, size_t src_offset = 0, unsigned dest_mip_index = 0, unsigned dest_array_index = 0);
 
-    void copy(texture const& src, texture const& dest);
+    /// copies all array slices at the given MIP level from src to dest
+    void copy(texture const& src, texture const& dest, unsigned mip_index = 0);
+    /// copies MIP level 0, array slice 0 from src to dest
     void copy(texture const& src, render_target const& dest);
+    /// copies src to MIP level 0, array slice 0 of dest
     void copy(render_target const& src, texture const& dest);
+    /// copies contents of src to dest
     void copy(render_target const& src, render_target const& dest);
+
+    /// copy textures specifying all details of the operation
+    void copy_subsection(texture const& src,
+                         texture const& dest,
+                         unsigned src_mip_index,
+                         unsigned src_array_index,
+                         unsigned dest_mip_index,
+                         unsigned dest_array_index,
+                         unsigned num_array_slices,
+                         tg::isize2 dest_size);
 
     /// resolve a multisampled render target to a texture or different RT
     void resolve(render_target const& src, texture const& dest);
@@ -183,7 +197,7 @@ private:
 
     void flushPendingTransitions();
 
-    void copyTextureInternal(phi::handle::resource src, phi::handle::resource dest, int w, int h);
+    void copyTextureInternal(phi::handle::resource src, phi::handle::resource dest, int w, int h, unsigned mip_index, unsigned first_array_index, unsigned num_array_slices);
     void resolveTextureInternal(phi::handle::resource src, phi::handle::resource dest, int w, int h);
 
     phi::handle::pipeline_state acquireComputePSO(compute_pass_info const& cp);

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -81,8 +81,13 @@ public:
     //
     // commands
 
+    /// copy buffer to buffer
     void copy(buffer const& src, buffer const& dest, size_t src_offset = 0, size_t dest_offset = 0, size_t num_bytes = 0);
+    /// copy buffer to texture
     void copy(buffer const& src, texture const& dest, size_t src_offset = 0, unsigned dest_mip_index = 0, unsigned dest_array_index = 0);
+
+    /// copy texture to buffer
+    void copy(render_target const& src, buffer const& dest, size_t dest_offset = 0);
 
     /// copies all array slices at the given MIP level from src to dest
     void copy(texture const& src, texture const& dest, unsigned mip_index = 0);

--- a/src/phantasm-renderer/Framebuffer.cc
+++ b/src/phantasm-renderer/Framebuffer.cc
@@ -9,6 +9,11 @@ pr::raii::GraphicsPass pr::raii::Framebuffer::make_pass(const pr::graphics_pass_
     return {mParent, mParent->framebufferAcquireGraphicsPSO(gp, mHashInfo, mNumSamples)};
 }
 
+void pr::raii::Framebuffer::sort_drawcalls_by_pso(unsigned num_drawcalls)
+{
+    mParent->framebufferOnSortByPSO(num_drawcalls);
+}
+
 void pr::raii::Framebuffer::destroy()
 {
     if (mParent)

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -35,6 +35,10 @@ public:
     /// this hits a OS mutex and might have to build a PSO (expensive)
     [[nodiscard]] GraphicsPass make_pass(graphics_pass_info const& gp) &;
 
+    /// sort previously recorded drawcalls by PSO - advanced feature
+    /// requires #num_drawcalls contiguously recorded drawcalls
+    void sort_drawcalls_by_pso(unsigned num_drawcalls);
+
 public:
     // redirect intuitive misuses
     [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pipeline_state const&) && = delete;

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -39,11 +39,18 @@ public:
 
     void set_constant_buffer_offset(unsigned offset);
 
+
     template <class T>
     void write_constants(T const& val)
     {
         mCmd.write_root_constants<T>(val);
     }
+
+    /// NOTE: advanced usage
+    phi::cmd::draw& raw_command() { return mCmd; }
+
+    /// NOTE: advanced usage
+    void reset_pipeline_state(phi::handle::pipeline_state pso) { mCmd.pipeline_state = pso; }
 
     GraphicsPass(GraphicsPass&& rhs) = default;
 


### PR DESCRIPTION
- Fix default texture-to-texture copy for arrays and cubemaps
- Add texture/render_target to buffer copy
- Improve other overloads with specifiable mip index
- Add `Context::calculate_texture_pixel_offset`
- Add some advanced usage utilities