### PR TITLE
Multi-Swapchain API [breaking]

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -21,7 +21,7 @@ public:
     CompiledFrame(CompiledFrame const&) = delete;
     CompiledFrame& operator=(CompiledFrame const&) = delete;
     CompiledFrame(CompiledFrame&& rhs) noexcept
-      : parent(rhs.parent), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables)), should_present_after_submit(rhs.should_present_after_submit)
+      : parent(rhs.parent), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables)), present_after_submit_swapchain(rhs.present_after_submit_swapchain)
     {
         rhs.parent = nullptr;
     }
@@ -34,7 +34,7 @@ public:
             parent = rhs.parent;
             cmdlist = rhs.cmdlist;
             freeables = cc::move(rhs.freeables);
-            should_present_after_submit = rhs.should_present_after_submit;
+            present_after_submit_swapchain = rhs.present_after_submit_swapchain;
             rhs.parent = nullptr;
         }
 
@@ -45,8 +45,8 @@ public:
 
 private:
     friend class Context;
-    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::vector<freeable_cached_obj>&& freeables, bool present_after_submit)
-      : parent(parent), cmdlist(cmdlist), freeables(cc::move(freeables)), should_present_after_submit(present_after_submit)
+    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::vector<freeable_cached_obj>&& freeables, phi::handle::swapchain present_after_submit_sc)
+      : parent(parent), cmdlist(cmdlist), freeables(cc::move(freeables)), present_after_submit_swapchain(present_after_submit_sc)
     {
     }
 
@@ -55,6 +55,6 @@ private:
     Context* parent = nullptr;
     phi::handle::command_list cmdlist = phi::handle::null_command_list;
     cc::vector<freeable_cached_obj> freeables;
-    bool should_present_after_submit = false;
+    phi::handle::swapchain present_after_submit_swapchain = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -193,6 +193,13 @@ auto_query_range Context::make_query_range(phi::query_type type, unsigned num_qu
     return auto_query_range{{handle, type, num_queries}, this};
 }
 
+swapchain Context::make_swapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, pr::present_mode mode, unsigned num_backbuffers)
+{
+    return mBackend->createSwapchain(window_handle, initial_size, mode, num_backbuffers);
+}
+
+void Context::destroy_swapchain(swapchain sc) { mBackend->free(sc); }
+
 void Context::free_untyped(phi::handle::resource resource) { mBackend->free(resource); }
 
 void Context::free(const fence& f) { mBackend->free(cc::span{f.handle}); }
@@ -337,12 +344,12 @@ CompiledFrame Context::compile(raii::Frame&& frame)
 
     if (frame.is_empty())
     {
-        return CompiledFrame(this, phi::handle::null_command_list, cc::move(frame.mFreeables), false);
+        return CompiledFrame(this, phi::handle::null_command_list, cc::move(frame.mFreeables), phi::handle::null_swapchain);
     }
     else
     {
         auto const cmdlist = mBackend->recordCommandList(frame.getMemory(), frame.getSize()); // intern. synced
-        return CompiledFrame(this, cmdlist, cc::move(frame.mFreeables), frame.mPresentAfterSubmitRequested);
+        return CompiledFrame(this, cmdlist, cc::move(frame.mFreeables), frame.mPresentAfterSubmitRequest);
     }
 }
 
@@ -361,9 +368,9 @@ gpu_epoch_t Context::submit(CompiledFrame&& frame)
         mGpuEpochTracker.increment_epoch();
         res = mGpuEpochTracker.get_current_epoch_cpu();
 
-        if (frame.should_present_after_submit)
+        if (frame.present_after_submit_swapchain.is_valid())
         {
-            present();
+            present(frame.present_after_submit_swapchain);
         }
     }
 
@@ -380,12 +387,12 @@ void Context::discard(CompiledFrame&& frame)
     frame.parent = nullptr;
 }
 
-void Context::present()
+void Context::present(swapchain sc)
 {
 #ifdef CC_ENABLE_ASSERTIONS
     CC_ASSERT(mSafetyState.did_acquire_before_present && "Context::present without prior acquire_backbuffer");
 #endif
-    mBackend->present();
+    mBackend->present(sc);
 #ifdef CC_ENABLE_ASSERTIONS
     mSafetyState.did_acquire_before_present = false;
 #endif
@@ -405,15 +412,15 @@ bool Context::flush(gpu_epoch_t epoch)
 bool Context::start_capture() { return mBackend->startForcedDiagnosticCapture(); }
 bool Context::stop_capture() { return mBackend->endForcedDiagnosticCapture(); }
 
-void Context::on_window_resize(tg::isize2 size) { mBackend->onResize(size); }
+void Context::on_window_resize(swapchain sc, tg::isize2 size) { mBackend->onResize(sc, size); }
 
-bool Context::clear_backbuffer_resize() { return mBackend->clearPendingResize(); }
+bool Context::clear_backbuffer_resize(swapchain sc) { return mBackend->clearPendingResize(sc); }
 
-tg::isize2 Context::get_backbuffer_size() const { return mBackend->getBackbufferSize(); }
+tg::isize2 Context::get_backbuffer_size(swapchain sc) const { return mBackend->getBackbufferSize(sc); }
 
-phi::format Context::get_backbuffer_format() const { return mBackend->getBackbufferFormat(); }
+phi::format Context::get_backbuffer_format(swapchain sc) const { return mBackend->getBackbufferFormat(sc); }
 
-unsigned Context::get_num_backbuffers() const { return mBackend->getNumBackbuffers(); }
+unsigned Context::get_num_backbuffers(swapchain sc) const { return mBackend->getNumBackbuffers(sc); }
 
 unsigned Context::calculate_texture_upload_size(tg::isize3 size, phi::format fmt, unsigned num_mips) const
 {
@@ -456,14 +463,14 @@ unsigned Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg
     return pixel.y * row_width + pixel.x * bytes_per_pixel;
 }
 
-render_target Context::acquire_backbuffer()
+render_target Context::acquire_backbuffer(swapchain sc)
 {
-    auto const backbuffer = mBackend->acquireBackbuffer();
-    auto const size = mBackend->getBackbufferSize();
+    auto const backbuffer = mBackend->acquireBackbuffer(sc);
+    auto const size = mBackend->getBackbufferSize(sc);
 #ifdef CC_ENABLE_ASSERTIONS
     mSafetyState.did_acquire_before_present = true;
 #endif
-    return {{backbuffer, backbuffer.is_valid() ? acquireGuid() : 0}, {mBackend->getBackbufferFormat(), size.width, size.height, 1, 1, {0, 0, 0, 1}}};
+    return {{backbuffer, backbuffer.is_valid() ? acquireGuid() : 0}, {mBackend->getBackbufferFormat(sc), size.width, size.height, 1, 1, {0, 0, 0, 1}}};
 }
 
 unsigned Context::clear_resource_caches()
@@ -512,30 +519,22 @@ unsigned Context::clear_pipeline_state_cache()
     return num_frees;
 }
 
-Context::Context(phi::window_handle const& window_handle, backend type) { initialize(window_handle, type); }
-
-Context::Context(const phi::window_handle& window_handle, backend type, const phi::backend_config& config)
-{
-    initialize(window_handle, type, config);
-}
-
-Context::Context(phi::Backend* backend) { initialize(backend); }
-
-void Context::initialize(const phi::window_handle& window_handle, backend type)
+void Context::initialize(backend type)
 {
     phi::backend_config cfg;
 #ifndef CC_RELEASE
     cfg.validation = phi::validation_level::on_extended;
 #endif
-    initialize(window_handle, type, cfg);
+    initialize(type, cfg);
 }
 
-void Context::initialize(const phi::window_handle& window_handle, backend type, const phi::backend_config& config)
+void Context::initialize(backend type, const phi::backend_config& config)
 {
     CC_RUNTIME_ASSERT(mBackend == nullptr && "pr::Context double initialize");
 
     mOwnsBackend = true;
-    mBackend = detail::make_backend(type, window_handle, config);
+    mBackend = detail::make_backend(type);
+    mBackend->initialize(config);
     CC_RUNTIME_ASSERT(mBackend != nullptr && "Failed to create backend");
     internalInitialize();
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -335,7 +335,7 @@ CompiledFrame Context::compile(raii::Frame&& frame)
 {
     frame.finalize();
 
-    if (frame.isEmpty())
+    if (frame.is_empty())
     {
         return CompiledFrame(this, phi::handle::null_command_list, cc::move(frame.mFreeables), false);
     }

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -271,11 +271,11 @@ public:
 
     /// frees all shader_views from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    [[deprecated("unimplemented")]] unsigned clear_shader_view_cache();
+    unsigned clear_shader_view_cache();
 
     /// frees all pipeline_states from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    [[deprecated("unimplemented")]] unsigned clear_pipeline_state_cache();
+    unsigned clear_pipeline_state_cache();
 
     //
     // phi interop

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -191,7 +191,7 @@ public:
     void write_to_buffer(buffer const& buffer, T const& data, size_t offset_in_buffer = 0)
     {
         static_assert(!std::is_pointer_v<T>, "[pr::Context::write_to_buffer_t] Pointer instead of raw data provided");
-        write_to_buffer_raw(buffer, cc::as_byte_span<T const>(data), offset_in_buffer);
+        write_to_buffer_raw(buffer, cc::as_byte_span(data), offset_in_buffer);
     }
 
     /// map a readback buffer, memcpy its contents to the provided location, and unmap it
@@ -200,7 +200,7 @@ public:
     void read_from_buffer(buffer const& buffer, T& out_data, size_t offset_in_buffer = 0)
     {
         static_assert(!std::is_pointer_v<T>, "[pr::Context::read_from_buffer_t] Pointer instead of raw data provided");
-        read_from_buffer_raw(buffer, cc::as_byte_span<T>(out_data), offset_in_buffer);
+        read_from_buffer_raw(buffer, cc::as_byte_span(out_data), offset_in_buffer);
     }
 
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -102,12 +102,10 @@ public:
     [[nodiscard]] auto_query_range make_query_range(pr::query_type type, unsigned num_queries);
 
     /// create a swapchain
-    [[nodiscard]] swapchain make_swapchain(phi::window_handle const& window_handle,
-                                           tg::isize2 initial_size,
-                                           pr::present_mode mode = pr::present_mode::synced,
-                                           unsigned num_backbuffers = 3);
-
-    void destroy_swapchain(pr::swapchain sc);
+    [[nodiscard]] auto_swapchain make_swapchain(phi::window_handle const& window_handle,
+                                                tg::isize2 initial_size,
+                                                pr::present_mode mode = pr::present_mode::synced,
+                                                unsigned num_backbuffers = 3);
 
     //
     // cache lookup API
@@ -165,6 +163,7 @@ public:
     }
     void free(fence const& f);
     void free(query_range const& q);
+    void free(swapchain const& sc);
 
     /// free a resource of undetermined type by placing it in the cache for reuse
     void free_to_cache_untyped(raw_resource const& resource, generic_resource_info const& info);
@@ -248,7 +247,7 @@ public:
     void discard(CompiledFrame&& frame);
 
     /// flips backbuffers
-    void present(swapchain sc);
+    void present(swapchain const& sc);
 
     /// blocks on the CPU until all pending GPU operations are done
     void flush();
@@ -257,10 +256,10 @@ public:
     /// returns false if the epoch was reached already, or flushes and returns true
     bool flush(gpu_epoch_t epoch);
 
-    void on_window_resize(swapchain sc, tg::isize2 size);
-    [[nodiscard]] bool clear_backbuffer_resize(swapchain sc);
+    void on_window_resize(swapchain const& sc, tg::isize2 size);
+    [[nodiscard]] bool clear_backbuffer_resize(swapchain const& sc);
 
-    [[nodiscard]] render_target acquire_backbuffer(swapchain sc);
+    [[nodiscard]] render_target acquire_backbuffer(swapchain const& sc);
 
     //
     // cache management
@@ -305,9 +304,9 @@ public:
     // info
     //
 
-    tg::isize2 get_backbuffer_size(swapchain sc) const;
-    format get_backbuffer_format(swapchain sc) const;
-    unsigned get_num_backbuffers(swapchain sc) const;
+    tg::isize2 get_backbuffer_size(swapchain const& sc) const;
+    format get_backbuffer_format(swapchain const& sc) const;
+    unsigned get_num_backbuffers(swapchain const& sc) const;
     uint64_t get_gpu_timestamp_frequency() const { return mGPUTimestampFrequency; }
 
     double get_timestamp_difference_milliseconds(uint64_t start, uint64_t end) const
@@ -372,11 +371,12 @@ public:
 
     // auto_ types are not to be freed manually, only free unlocked types
     template <class T, bool Cached>
-    void free(auto_destroyer<T, Cached> const&) = delete;
+    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free(auto_destroyer<T, Cached> const&) = delete;
 
     // auto_ types are not to be freed manually, only free unlocked types
     template <class T, bool Cached>
-    void free_to_cache(auto_destroyer<T, Cached> const&) = delete;
+    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_to_cache(auto_destroyer<T, Cached> const&)
+        = delete;
 
 private:
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -101,6 +101,14 @@ public:
     /// create a contiguous range of queries
     [[nodiscard]] auto_query_range make_query_range(pr::query_type type, unsigned num_queries);
 
+    /// create a swapchain
+    [[nodiscard]] swapchain make_swapchain(phi::window_handle const& window_handle,
+                                           tg::isize2 initial_size,
+                                           pr::present_mode mode = pr::present_mode::synced,
+                                           unsigned num_backbuffers = 3);
+
+    void destroy_swapchain(pr::swapchain sc);
+
     //
     // cache lookup API
     //
@@ -240,7 +248,7 @@ public:
     void discard(CompiledFrame&& frame);
 
     /// flips backbuffers
-    void present();
+    void present(swapchain sc);
 
     /// blocks on the CPU until all pending GPU operations are done
     void flush();
@@ -249,10 +257,10 @@ public:
     /// returns false if the epoch was reached already, or flushes and returns true
     bool flush(gpu_epoch_t epoch);
 
-    void on_window_resize(tg::isize2 size);
-    [[nodiscard]] bool clear_backbuffer_resize();
+    void on_window_resize(swapchain sc, tg::isize2 size);
+    [[nodiscard]] bool clear_backbuffer_resize(swapchain sc);
 
-    [[nodiscard]] render_target acquire_backbuffer();
+    [[nodiscard]] render_target acquire_backbuffer(swapchain sc);
 
     //
     // cache management
@@ -297,9 +305,9 @@ public:
     // info
     //
 
-    tg::isize2 get_backbuffer_size() const;
-    format get_backbuffer_format() const;
-    unsigned get_num_backbuffers() const;
+    tg::isize2 get_backbuffer_size(swapchain sc) const;
+    format get_backbuffer_format(swapchain sc) const;
+    unsigned get_num_backbuffers(swapchain sc) const;
     uint64_t get_gpu_timestamp_frequency() const { return mGPUTimestampFrequency; }
 
     double get_timestamp_difference_milliseconds(uint64_t start, uint64_t end) const
@@ -343,16 +351,16 @@ public:
 
     Context() = default;
     /// internally create a backend with default config
-    Context(phi::window_handle const& window_handle, backend type = backend::vulkan);
+    Context(backend type) { initialize(type); }
     /// internally create a backend with specified config
-    Context(phi::window_handle const& window_handle, backend type, phi::backend_config const& config);
+    Context(backend type, phi::backend_config const& config) { initialize(type, config); }
     /// attach to an existing backend
-    Context(phi::Backend* backend);
+    Context(phi::Backend* backend) { initialize(backend); }
 
     ~Context() { destroy(); }
 
-    void initialize(phi::window_handle const& window_handle, backend type = backend::vulkan);
-    void initialize(phi::window_handle const& window_handle, backend type, phi::backend_config const& config);
+    void initialize(backend type);
+    void initialize(backend type, phi::backend_config const& config);
     void initialize(phi::Backend* backend);
 
     void destroy();

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -328,6 +328,7 @@ public:
 
     /// returns the underlying phantasm-hardware-interface backend
     phi::Backend& get_backend() { return *mBackend; }
+    pr::backend get_backend_type() const { return mBackendType; }
 
     /// monotonously increasing uint64, always greater or equal to GPU epoch
     gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker.get_current_epoch_cpu(); }
@@ -428,6 +429,7 @@ private:
     // backend
     phi::Backend* mBackend = nullptr;
     bool mOwnsBackend = false;
+    pr::backend mBackendType;
 
     // constant info
     uint64_t mGPUTimestampFrequency;

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -350,11 +350,11 @@ public:
 
     Context() = default;
     /// internally create a backend with default config
-    Context(backend type) { initialize(type); }
+    explicit Context(backend type) { initialize(type); }
     /// internally create a backend with specified config
-    Context(backend type, phi::backend_config const& config) { initialize(type, config); }
+    explicit Context(backend type, phi::backend_config const& config) { initialize(type, config); }
     /// attach to an existing backend
-    Context(phi::Backend* backend) { initialize(backend); }
+    explicit Context(phi::Backend* backend) { initialize(backend); }
 
     ~Context() { destroy(); }
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -71,11 +71,11 @@ public:
     void transition(phi::handle::resource raw_resource, state target, shader_flags dependency = {});
 
     /// transition the backbuffer to present state and trigger a Context::present after this frame is submitted
-    void present_after_submit(render_target const& backbuffer)
+    void present_after_submit(render_target const& backbuffer, swapchain sc)
     {
-        CC_ASSERT(!mPresentAfterSubmitRequested && "only one present_after_submit per pr::raii::Frame allowed");
+        CC_ASSERT(!mPresentAfterSubmitRequest.is_valid() && "only one present_after_submit per pr::raii::Frame allowed");
         transition(backbuffer, state::present);
-        mPresentAfterSubmitRequested = true;
+        mPresentAfterSubmitRequest = sc;
     }
 
     //
@@ -251,6 +251,6 @@ private:
     phi::cmd::transition_resources mPendingTransitionCommand;
     cc::vector<freeable_cached_obj> mFreeables;
     bool mFramebufferActive = false;
-    bool mPresentAfterSubmitRequested = false;
+    phi::handle::swapchain mPresentAfterSubmitRequest = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -75,7 +75,7 @@ public:
     {
         CC_ASSERT(!mPresentAfterSubmitRequest.is_valid() && "only one present_after_submit per pr::raii::Frame allowed");
         transition(backbuffer, state::present);
-        mPresentAfterSubmitRequest = sc;
+        mPresentAfterSubmitRequest = sc.handle;
     }
 
     //

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -159,6 +159,8 @@ public:
 
     Context& context() { return *mCtx; }
 
+    bool is_empty() const { return mWriter.is_empty(); }
+
 public:
     // redirect intuitive misuses
     /// (graphics passes can only be created from framebuffers)
@@ -241,7 +243,6 @@ private:
     void finalize();
     std::byte* getMemory() const { return mWriter.buffer(); }
     size_t getSize() const { return mWriter.size(); }
-    bool isEmpty() const { return mWriter.is_empty(); }
 
     // members
 private:

--- a/src/phantasm-renderer/Framebuffer.cc
+++ b/src/phantasm-renderer/Framebuffer.cc
@@ -9,10 +9,7 @@ pr::raii::GraphicsPass pr::raii::Framebuffer::make_pass(const pr::graphics_pass_
     return {mParent, mParent->framebufferAcquireGraphicsPSO(gp, mHashInfo, mNumSamples)};
 }
 
-void pr::raii::Framebuffer::sort_drawcalls_by_pso(unsigned num_drawcalls)
-{
-    mParent->framebufferOnSortByPSO(num_drawcalls);
-}
+void pr::raii::Framebuffer::sort_drawcalls_by_pso(unsigned num_drawcalls) { mParent->framebufferOnSortByPSO(num_drawcalls); }
 
 void pr::raii::Framebuffer::destroy()
 {

--- a/src/phantasm-renderer/detail/auto_destroyer.cc
+++ b/src/phantasm-renderer/detail/auto_destroyer.cc
@@ -15,4 +15,6 @@ void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pipeline_st
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::shader_binary& v) { ctx->free(v); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::prebuilt_argument& v) { ctx->freeShaderView(v._sv); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::fence& v) { ctx->free(v); }
+
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::query_range& v) { ctx->free(v); }
+void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::swapchain& v) { ctx->free(v); }

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -22,6 +22,7 @@ struct auto_destroy_proxy
     static void destroy(pr::Context* ctx, prebuilt_argument const& v);
     static void destroy(pr::Context* ctx, fence const& v);
     static void destroy(pr::Context* ctx, query_range const& v);
+    static void destroy(pr::Context* ctx, swapchain const& v);
 };
 }
 

--- a/src/phantasm-renderer/detail/backends.cc
+++ b/src/phantasm-renderer/detail/backends.cc
@@ -12,7 +12,7 @@
 #include <phantasm-hardware-interface/d3d12/BackendD3D12.hh>
 #endif
 
-phi::Backend* pr::detail::make_backend(backend type, phi::window_handle const& window_handle, const phi::backend_config& cfg)
+phi::Backend* pr::detail::make_backend(backend type)
 {
     phi::Backend* res = nullptr;
     if (type == backend::d3d12)
@@ -34,11 +34,6 @@ phi::Backend* pr::detail::make_backend(backend type, phi::window_handle const& w
     else
     {
         CC_RUNTIME_ASSERT(false && "unknown backend requested");
-    }
-
-    if (res != nullptr)
-    {
-        res->initialize(cfg, window_handle);
     }
 
     return res;

--- a/src/phantasm-renderer/detail/backends.hh
+++ b/src/phantasm-renderer/detail/backends.hh
@@ -5,5 +5,5 @@
 
 namespace pr::detail
 {
-[[nodiscard]] phi::Backend* make_backend(backend type, phi::window_handle const& window_handle, phi::backend_config const& cfg);
+[[nodiscard]] phi::Backend* make_backend(backend type);
 }

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -34,7 +34,6 @@ using phi::sampler_filter;
 // type renames
 using shader_flags = phi::shader_stage_flags_t;
 using clear_value = phi::rt_clear_value;
-using swapchain = phi::handle::swapchain;
 
 // type passthroughs
 using phi::blend_state;

--- a/src/phantasm-renderer/enums.hh
+++ b/src/phantasm-renderer/enums.hh
@@ -21,6 +21,7 @@ using phi::blend_logic_op;
 using phi::blend_op;
 using phi::cull_mode;
 using phi::depth_function;
+using phi::present_mode;
 using phi::primitive_topology;
 using phi::query_type;
 using phi::queue_type;
@@ -33,6 +34,7 @@ using phi::sampler_filter;
 // type renames
 using shader_flags = phi::shader_stage_flags_t;
 using clear_value = phi::rt_clear_value;
+using swapchain = phi::handle::swapchain;
 
 // type passthroughs
 using phi::blend_state;

--- a/src/phantasm-renderer/fwd.hh
+++ b/src/phantasm-renderer/fwd.hh
@@ -46,11 +46,13 @@ struct graphics_pipeline_state;
 struct compute_pipeline_state;
 struct fence;
 struct query_range;
+struct swapchain;
 using auto_shader_binary = auto_destroyer<shader_binary, false>;
 using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, false>;
 using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
 using auto_fence = auto_destroyer<fence, false>;
 using auto_query_range = auto_destroyer<query_range, false>;
+using auto_swapchain = auto_destroyer<swapchain, false>;
 
 // shader arguments
 struct argument;

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -84,6 +84,11 @@ struct query_range
     unsigned num;
 };
 
+struct swapchain
+{
+    phi::handle::swapchain handle = phi::handle::null_swapchain;
+};
+
 //
 // auto_ and cached_ aliases
 
@@ -97,6 +102,7 @@ using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, fal
 using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
 using auto_fence = auto_destroyer<fence, false>;
 using auto_query_range = auto_destroyer<query_range, false>;
+using auto_swapchain = auto_destroyer<swapchain, false>;
 
 // move-only, self-cachefreeing versions
 using cached_buffer = auto_destroyer<buffer, true>;


### PR DESCRIPTION
- Add `pr::swapchain` (breaking)
    - Window handle no longer part of init, swapchains created explicitly
    - Taken as an argument on previously global calls (present, present_after_submit, acquire_backbuffer, etc)
- Fix texture upload size and texture buffer offset calculation utilities for vulkan
- Finish implementation of `clear_shader_view_cache` and `clear_pipeline_state_cache`