### PR TITLE
Debug names, allocator support for Frame, minor changes

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <clean-core/vector.hh>
+#include <clean-core/alloc_vector.hh>
 
 #include <phantasm-hardware-interface/handles.hh>
 
@@ -45,7 +45,7 @@ public:
 
 private:
     friend class Context;
-    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::vector<freeable_cached_obj>&& freeables, phi::handle::swapchain present_after_submit_sc)
+    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::alloc_vector<freeable_cached_obj>&& freeables, phi::handle::swapchain present_after_submit_sc)
       : parent(parent), cmdlist(cmdlist), freeables(cc::move(freeables)), present_after_submit_swapchain(present_after_submit_sc)
     {
     }
@@ -54,7 +54,7 @@ private:
 
     Context* parent = nullptr;
     phi::handle::command_list cmdlist = phi::handle::null_command_list;
-    cc::vector<freeable_cached_obj> freeables;
+    cc::alloc_vector<freeable_cached_obj> freeables;
     phi::handle::swapchain present_after_submit_swapchain = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -41,11 +41,7 @@ dxcw::target stage_to_dxcw_target(phi::shader_stage stage)
 
 }
 
-raii::Frame Context::make_frame(size_t initial_size)
-{
-    // TODO: pool the memory blocks for frames
-    return {this, initial_size};
-}
+raii::Frame Context::make_frame(size_t initial_size, cc::allocator* alloc) { return pr::raii::Frame{this, initial_size, alloc}; }
 
 auto_texture Context::make_texture(int width, phi::format format, unsigned num_mips, bool allow_uav)
 {

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -463,10 +463,10 @@ unsigned Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg
     return pixel.y * row_width + pixel.x * bytes_per_pixel;
 }
 
-void Context::set_debug_name(const texture& tex, const char* name) { mBackend->setDebugName(tex.res.handle, name); }
-void Context::set_debug_name(const render_target& rt, const char* name) { mBackend->setDebugName(rt.res.handle, name); }
-void Context::set_debug_name(const buffer& buf, const char* name) { mBackend->setDebugName(buf.res.handle, name); }
-void Context::set_debug_name(phi::handle::resource raw_res, const char* name) { mBackend->setDebugName(raw_res, name); }
+void Context::set_debug_name(const texture& tex, cc::string_view name) { mBackend->setDebugName(tex.res.handle, name); }
+void Context::set_debug_name(const render_target& rt, cc::string_view name) { mBackend->setDebugName(rt.res.handle, name); }
+void Context::set_debug_name(const buffer& buf, cc::string_view name) { mBackend->setDebugName(buf.res.handle, name); }
+void Context::set_debug_name(phi::handle::resource raw_res, cc::string_view name) { mBackend->setDebugName(raw_res, name); }
 
 render_target Context::acquire_backbuffer(swapchain const& sc)
 {

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -1,5 +1,7 @@
 #include "Context.hh"
 
+#include <typed-geometry/tg.hh>
+
 #include <clean-core/xxHash.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
@@ -43,78 +45,81 @@ dxcw::target stage_to_dxcw_target(phi::shader_stage stage)
 
 raii::Frame Context::make_frame(size_t initial_size, cc::allocator* alloc) { return pr::raii::Frame{this, initial_size, alloc}; }
 
-auto_texture Context::make_texture(int width, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture(int width, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info{format, phi::texture_dimension::t1d, allow_uav, width, 1, 1, num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info{format, phi::texture_dimension::t2d, allow_uav, size.width, size.height, 1, num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture(tg::isize3 size, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture(tg::isize3 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info
         = texture_info{format, phi::texture_dimension::t3d, allow_uav, size.width, size.height, static_cast<unsigned int>(size.depth), num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_cube(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture_cube(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info{format, phi::texture_dimension::t2d, allow_uav, size.width, size.height, 6, num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_array(int width, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture_array(int width, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info{format, phi::texture_dimension::t1d, allow_uav, width, 1, num_elems, num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_array(tg::isize2 size, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav)
+auto_texture Context::make_texture_array(tg::isize2 size, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info{format, phi::texture_dimension::t2d, allow_uav, size.width, size.height, num_elems, num_mips};
-    return {createTexture(info), this};
+    return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture(const texture_info& info) { return {createTexture(info), this}; }
+auto_texture Context::make_texture(const texture_info& info, char const* debug_name) { return {createTexture(info, debug_name), this}; }
 
-auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size)
+auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, char const* debug_name)
 {
     auto const info = render_target_info::create(format, size, num_samples, array_size);
-    return {createRenderTarget(info), this};
+    return {createRenderTarget(info, debug_name), this};
 }
 
-auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear)
+auto_render_target Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear, char const* debug_name)
 {
     auto const info = render_target_info::create(format, size, num_samples, array_size, optimized_clear);
-    return {createRenderTarget(info), this};
+    return {createRenderTarget(info, debug_name), this};
 }
 
-auto_render_target Context::make_target(const render_target_info& info) { return {createRenderTarget(info), this}; }
+auto_render_target Context::make_target(const render_target_info& info, char const* debug_name)
+{
+    return {createRenderTarget(info, debug_name), this};
+}
 
-auto_buffer Context::make_buffer(unsigned size, unsigned stride, bool allow_uav)
+auto_buffer Context::make_buffer(unsigned size, unsigned stride, bool allow_uav, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, allow_uav, phi::resource_heap::gpu};
-    return {createBuffer(info), this};
+    return {createBuffer(info, debug_name), this};
 }
 
-auto_buffer Context::make_upload_buffer(unsigned size, unsigned stride)
+auto_buffer Context::make_upload_buffer(unsigned size, unsigned stride, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::upload};
-    return {createBuffer(info), this};
+    return {createBuffer(info, debug_name), this};
 }
 
-auto_buffer Context::make_readback_buffer(unsigned size, unsigned stride)
+auto_buffer Context::make_readback_buffer(unsigned size, unsigned stride, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::readback};
-    return {createBuffer(info), this};
+    return {createBuffer(info, debug_name), this};
 }
 
-auto_buffer Context::make_buffer(const buffer_info& info) { return {createBuffer(info), this}; }
+auto_buffer Context::make_buffer(const buffer_info& info, char const* debug_name) { return {createBuffer(info, debug_name), this}; }
 
 auto_shader_binary Context::make_shader(cc::span<cc::byte const> data, phi::shader_stage stage)
 {
@@ -298,16 +303,16 @@ cached_buffer Context::get_buffer(const buffer_info& info) { return {acquireBuff
 
 cached_texture Context::get_texture(const texture_info& info) { return {acquireTexture(info), this}; }
 
-raw_resource Context::make_untyped_unlocked(const generic_resource_info& info)
+raw_resource Context::make_untyped_unlocked(const generic_resource_info& info, const char* debug_name)
 {
     switch (info.type)
     {
     case phi::arg::create_resource_info::e_resource_render_target:
-        return createRenderTarget(info.info_render_target).res;
+        return createRenderTarget(info.info_render_target, debug_name).res;
     case phi::arg::create_resource_info::e_resource_texture:
-        return createTexture(info.info_texture).res;
+        return createTexture(info.info_texture, debug_name).res;
     case phi::arg::create_resource_info::e_resource_buffer:
-        return createBuffer(info.info_buffer).res;
+        return createBuffer(info.info_buffer, debug_name).res;
     default:
         CC_ASSERT(false && "invalid type");
         return {};
@@ -592,18 +597,21 @@ void Context::internalInitialize()
     mBackendType = mBackend->getBackendType() == phi::backend_type::d3d12 ? pr::backend::d3d12 : pr::backend::vulkan;
 }
 
-render_target Context::createRenderTarget(const render_target_info& info)
+render_target Context::createRenderTarget(const render_target_info& info, char const* dbg_name)
 {
-    return {{mBackend->createRenderTargetFromInfo(info), acquireGuid()}, info};
+    return {{mBackend->createRenderTargetFromInfo(info, dbg_name), acquireGuid()}, info};
 }
 
-texture Context::createTexture(const texture_info& info) { return {{mBackend->createTextureFromInfo(info), acquireGuid()}, info}; }
+texture Context::createTexture(const texture_info& info, const char* dbg_name)
+{
+    return {{mBackend->createTextureFromInfo(info, dbg_name), acquireGuid()}, info};
+}
 
-buffer Context::createBuffer(const buffer_info& info)
+buffer Context::createBuffer(const buffer_info& info, char const* dbg_name)
 {
     CC_ASSERT((info.allow_uav ? info.heap == phi::resource_heap::gpu : true) && "mapped buffers cannot be created with UAV support");
 
-    phi::handle::resource handle = mBackend->createBufferFromInfo(info);
+    phi::handle::resource handle = mBackend->createBufferFromInfo(info, dbg_name);
     return {{handle, acquireGuid()}, info};
 }
 
@@ -748,3 +756,8 @@ void Context::free_compute_pso(cc::hash_t hash) { mCacheComputePSOs.free(hash, m
 
 void Context::free_graphics_sv(cc::hash_t hash) { mCacheGraphicsSVs.free(hash, mGpuEpochTracker.get_current_epoch_cpu()); }
 void Context::free_compute_sv(cc::hash_t hash) { mCacheComputeSVs.free(hash, mGpuEpochTracker.get_current_epoch_cpu()); }
+
+auto_buffer pr::Context::make_upload_buffer_for_texture(const texture& tex, unsigned num_mips, const char* debug_name)
+{
+    return make_upload_buffer(calculate_texture_upload_size(tex, num_mips), 0, debug_name);
+}

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -463,6 +463,11 @@ unsigned Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg
     return pixel.y * row_width + pixel.x * bytes_per_pixel;
 }
 
+void Context::set_debug_name(const texture& tex, const char* name) { mBackend->setDebugName(tex.res.handle, name); }
+void Context::set_debug_name(const render_target& rt, const char* name) { mBackend->setDebugName(rt.res.handle, name); }
+void Context::set_debug_name(const buffer& buf, const char* name) { mBackend->setDebugName(buf.res.handle, name); }
+void Context::set_debug_name(phi::handle::resource raw_res, const char* name) { mBackend->setDebugName(raw_res, name); }
+
 render_target Context::acquire_backbuffer(swapchain const& sc)
 {
     auto const backbuffer = mBackend->acquireBackbuffer(sc.handle);

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -320,18 +320,26 @@ public:
     unsigned get_num_backbuffers(swapchain const& sc) const;
     uint64_t get_gpu_timestamp_frequency() const { return mGPUTimestampFrequency; }
 
+    /// returns the difference between two GPU timestamp values in milliseconds
     double get_timestamp_difference_milliseconds(uint64_t start, uint64_t end) const
     {
         return (double(end - start) / mGPUTimestampFrequency) * 1000.;
     }
+    /// returns the difference between two GPU timestamp values in microseconds
+    uint64_t get_timestamp_difference_microseconds(uint64_t start, uint64_t end) const
+    {
+        return (end - start) / (mGPUTimestampFrequency / 1'000'000);
+    }
 
     /// returns the amount of bytes needed to store the contents of a texture (in a GPU buffer)
+    /// ex. use case: allocating upload buffers of the right size to upload textures
     unsigned calculate_texture_upload_size(tg::isize3 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(int width, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(texture const& texture, unsigned num_mips = 1) const;
 
     /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
+    /// ex. use case: copying a render target to a readback buffer, then reading the pixel at this offset
     unsigned calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const;
 
 

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -339,6 +339,13 @@ public:
     // miscellaneous
     //
 
+    /// resets the debug name of a resource
+    /// this is the name visible to diagnostic tools and referred to by validation warnings
+    void set_debug_name(texture const& tex, char const* name);
+    void set_debug_name(render_target const& rt, char const* name);
+    void set_debug_name(buffer const& buf, char const* name);
+    void set_debug_name(phi::handle::resource raw_res, char const* name);
+
     /// attempts to start a capture in a connected tool like Renderdoc, PIX, NSight etc
     bool start_capture();
     /// ends a capture previously started with start_capture()

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -349,10 +349,10 @@ public:
 
     /// resets the debug name of a resource
     /// this is the name visible to diagnostic tools and referred to by validation warnings
-    void set_debug_name(texture const& tex, char const* name);
-    void set_debug_name(render_target const& rt, char const* name);
-    void set_debug_name(buffer const& buf, char const* name);
-    void set_debug_name(phi::handle::resource raw_res, char const* name);
+    void set_debug_name(texture const& tex, cc::string_view name);
+    void set_debug_name(render_target const& rt, cc::string_view name);
+    void set_debug_name(buffer const& buf, cc::string_view name);
+    void set_debug_name(phi::handle::resource raw_res, cc::string_view name);
 
     /// attempts to start a capture in a connected tool like Renderdoc, PIX, NSight etc
     bool start_capture();
@@ -393,7 +393,7 @@ public:
     bool is_initialized() const { return mBackend != nullptr; }
 
 public:
-    // deleted overrides
+    // deleted overridess
 
     // auto_ types are not to be freed manually, only free unlocked types
     template <class T, bool Cached>

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -40,43 +40,54 @@ public:
     [[nodiscard]] raii::Frame make_frame(size_t initial_size = 2048, cc::allocator* alloc = cc::system_allocator);
 
     /// create a 1D texture
-    [[nodiscard]] auto_texture make_texture(int width, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture(int width, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a 2D texture
-    [[nodiscard]] auto_texture make_texture(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a 3D texture
-    [[nodiscard]] auto_texture make_texture(tg::isize3 size, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture(tg::isize3 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a texture cube
-    [[nodiscard]] auto_texture make_texture_cube(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture_cube(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a 1D texture array
-    [[nodiscard]] auto_texture make_texture_array(int width, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture_array(int width, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a 2D texture array
-    [[nodiscard]] auto_texture make_texture_array(tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false);
+    [[nodiscard]] auto_texture make_texture_array(
+        tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a texture from an info struct
-    [[nodiscard]] auto_texture make_texture(texture_info const& info);
+    [[nodiscard]] auto_texture make_texture(texture_info const& info, char const* debug_name = nullptr);
     /// create a texture from the info of a different texture. NOTE: does not concern contents or state
-    [[nodiscard]] auto_texture make_texture_clone(texture const& clone_source) { return make_texture(clone_source.info); }
+    [[nodiscard]] auto_texture make_texture_clone(texture const& clone_source, char const* debug_name = nullptr)
+    {
+        return make_texture(clone_source.info, debug_name);
+    }
 
     /// create a render target
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1, char const* debug_name = nullptr);
     /// create a render target with an optimized clear value
-    [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
+    [[nodiscard]] auto_render_target make_target(
+        tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear, char const* debug_name = nullptr);
     /// create a render target from an info struct
-    [[nodiscard]] auto_render_target make_target(render_target_info const& info);
+    [[nodiscard]] auto_render_target make_target(render_target_info const& info, char const* debug_name = nullptr);
     /// create a render target from the info of a different one. NOTE: does not concern contents or state
-    [[nodiscard]] auto_render_target make_target_clone(render_target const& clone_source) { return make_target(clone_source.info); }
+    [[nodiscard]] auto_render_target make_target_clone(render_target const& clone_source, char const* debug_name = nullptr)
+    {
+        return make_target(clone_source.info, debug_name);
+    }
 
     /// create a buffer
-    [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
+    [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false, char const* debug_name = nullptr);
     /// create a mapped upload buffer which can be directly written to from CPU
-    [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0);
+    [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
     /// create a mapped upload buffer, with a size based on accomodating a given texture's contents
-    [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1);
+    [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1, char const* debug_name = nullptr);
     /// create a mapped readback buffer which can be directly read from CPU
-    [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0);
+    [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
     /// create a buffer from an info struct
-    [[nodiscard]] auto_buffer make_buffer(buffer_info const& info);
+    [[nodiscard]] auto_buffer make_buffer(buffer_info const& info, char const* debug_name = nullptr);
     /// create a buffer from the info of a different buffer. NOTE: does not concern contents or state
-    [[nodiscard]] auto_buffer make_buffer_clone(buffer const& clone_source) { return make_buffer(clone_source.info); }
+    [[nodiscard]] auto_buffer make_buffer_clone(buffer const& clone_source, char const* debug_name = nullptr)
+    {
+        return make_buffer(clone_source.info, debug_name);
+    }
 
 
     /// create a shader from binary data
@@ -133,7 +144,7 @@ public:
     //
 
     /// create a resource of undetermined type, without RAII management (use free_untyped)
-    [[nodiscard]] raw_resource make_untyped_unlocked(generic_resource_info const& info);
+    [[nodiscard]] raw_resource make_untyped_unlocked(generic_resource_info const& info, char const* debug_name = nullptr);
 
     /// create or retrieve a resource of undetermined type from cache, without RAII management (use free_to_cache_untyped)
     [[nodiscard]] raw_resource get_untyped_unlocked(generic_resource_info const& info);
@@ -395,9 +406,9 @@ private:
     void internalInitialize();
 
     // creation
-    render_target createRenderTarget(render_target_info const& info);
-    texture createTexture(texture_info const& info);
-    buffer createBuffer(buffer_info const& info);
+    render_target createRenderTarget(render_target_info const& info, char const* dbg_name = nullptr);
+    texture createTexture(texture_info const& info, char const* dbg_name = nullptr);
+    buffer createBuffer(buffer_info const& info, char const* dbg_name = nullptr);
 
     // multi cache acquire
     render_target acquireRenderTarget(render_target_info const& info);
@@ -468,11 +479,6 @@ private:
     } mSafetyState;
 #endif
 };
-
-inline auto_buffer Context::make_upload_buffer_for_texture(const texture& tex, unsigned num_mips)
-{
-    return make_upload_buffer(calculate_texture_upload_size(tex, num_mips));
-}
 
 inline unsigned Context::calculate_texture_upload_size(tg::isize2 size, pr::format fmt, unsigned num_mips) const
 {

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -393,7 +393,7 @@ public:
     bool is_initialized() const { return mBackend != nullptr; }
 
 public:
-    // deleted overridess
+    // deleted overrides
 
     // auto_ types are not to be freed manually, only free unlocked types
     template <class T, bool Cached>

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -37,7 +37,7 @@ public:
     //
 
     /// start a frame, allowing command recording
-    [[nodiscard]] raii::Frame make_frame(size_t initial_size = 2048);
+    [[nodiscard]] raii::Frame make_frame(size_t initial_size = 2048, cc::allocator* alloc = cc::system_allocator);
 
     /// create a 1D texture
     [[nodiscard]] auto_texture make_texture(int width, format format, unsigned num_mips = 0, bool allow_uav = false);

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -40,11 +40,11 @@ public:
 
         // add targets
         (addRenderTargetToFramebuffer(bcmd, num_samples, targets), ...);
-        return buildFramebuffer(bcmd, num_samples, nullptr);
+        return buildFramebuffer(bcmd, num_samples, nullptr, true);
     }
 
     /// create a framebuffer from a raw phi command
-    [[nodiscard]] Framebuffer make_framebuffer(phi::cmd::begin_render_pass const& raw_command) &;
+    [[nodiscard]] Framebuffer make_framebuffer(phi::cmd::begin_render_pass const& raw_command, bool auto_transition = true) &;
 
     /// create a framebuffer using a builder with more configuration options
     [[nodiscard]] framebuffer_builder build_framebuffer() & { return {this}; }
@@ -202,7 +202,7 @@ private:
     // framebuffer_builder-side API
 private:
     friend struct framebuffer_builder;
-    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples, const phi::arg::framebuffer_config* blendstate_override);
+    Framebuffer buildFramebuffer(phi::cmd::begin_render_pass const& bcmd, int num_samples, const phi::arg::framebuffer_config* blendstate_override, bool auto_transition);
 
     // Framebuffer-side API
 private:

--- a/src/phantasm-renderer/Framebuffer.cc
+++ b/src/phantasm-renderer/Framebuffer.cc
@@ -19,5 +19,5 @@ void pr::raii::Framebuffer::destroy()
 
 pr::raii::Framebuffer pr::raii::framebuffer_builder::make()
 {
-    return _parent->buildFramebuffer(_cmd, _num_samples, _has_custom_blendstate ? &_blendstate_overrides : nullptr);
+    return _parent->buildFramebuffer(_cmd, _num_samples, _has_custom_blendstate ? &_blendstate_overrides : nullptr, _wants_auto_transitions);
 }

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -160,6 +160,13 @@ public:
         return *this;
     }
 
+    /// disable automatical transitions of render and depth targets into fitting states
+    [[nodiscard]] framebuffer_builder& no_transitions()
+    {
+        _wants_auto_transitions = false;
+        return *this;
+    }
+
     /// create the framebuffer
     [[nodiscard]] Framebuffer make();
 
@@ -199,6 +206,8 @@ private:
     bool _has_custom_viewport = false;
     // if true, custom blendstate was specified
     bool _has_custom_blendstate = false;
+    // if true, wants the frame to automatically insert transitions for all render targets
+    bool _wants_auto_transitions = true;
     int _num_samples = -1; ///< amount of samples of the most recently added RT (-1 initially)
 };
 }

--- a/src/phantasm-renderer/common/growing_writer.cc
+++ b/src/phantasm-renderer/common/growing_writer.cc
@@ -2,7 +2,11 @@
 
 #include <cstdlib>
 
-pr::growing_writer::growing_writer(size_t initial_size) { _writer.initialize(static_cast<std::byte*>(std::malloc(initial_size)), initial_size); }
+pr::growing_writer::growing_writer(size_t initial_size, cc::allocator* alloc) : _alloc(alloc)
+{
+    CC_CONTRACT(alloc != nullptr);
+    _writer.initialize(_alloc->alloc(initial_size), initial_size);
+}
 
 pr::growing_writer& pr::growing_writer::operator=(pr::growing_writer&& rhs) noexcept
 {
@@ -10,33 +14,25 @@ pr::growing_writer& pr::growing_writer::operator=(pr::growing_writer&& rhs) noex
     {
         if (_writer.buffer() != nullptr)
         {
-            std::free(_writer.buffer());
+            _alloc->free(_writer.buffer());
         }
 
         _writer = rhs._writer;
+        _alloc = rhs._alloc;
         rhs._writer.exchange_buffer(nullptr, 0);
+        rhs._alloc = cc::system_allocator;
     }
     return *this;
 }
 
-pr::growing_writer::~growing_writer()
-{
-    if (_writer.buffer() != nullptr)
-    {
-        std::free(_writer.buffer());
-    }
-}
+pr::growing_writer::~growing_writer() { _alloc->free(_writer.buffer()); }
 
 void pr::growing_writer::accomodate(size_t cmd_size)
 {
     if (!_writer.can_accomodate(cmd_size))
     {
         size_t const new_size = (_writer.max_size() + cmd_size) << 1;
-        std::byte* const new_buffer = static_cast<std::byte*>(std::malloc(new_size));
-
-        std::memcpy(new_buffer, _writer.buffer(), _writer.size());
-
-        std::free(_writer.buffer());
+        std::byte* const new_buffer = _alloc->realloc(_writer.buffer(), _writer.max_size(), new_size);
         _writer.exchange_buffer(new_buffer, new_size);
     }
 }

--- a/src/phantasm-renderer/common/growing_writer.hh
+++ b/src/phantasm-renderer/common/growing_writer.hh
@@ -1,14 +1,21 @@
 #pragma once
 
+#include <clean-core/allocator.hh>
+
 #include <phantasm-hardware-interface/commands.hh>
 
 namespace pr
 {
-// naive growing writer, TODO: pool and reuse buffers
+// naive growing writer
 struct growing_writer
 {
-    growing_writer(size_t initial_size);
-    growing_writer(growing_writer&& rhs) noexcept : _writer(rhs._writer) { rhs._writer.exchange_buffer(nullptr, 0); }
+    growing_writer(size_t initial_size, cc::allocator* alloc = cc::system_allocator);
+    growing_writer(growing_writer&& rhs) noexcept : _writer(rhs._writer), _alloc(rhs._alloc)
+    {
+        rhs._writer.exchange_buffer(nullptr, 0);
+        rhs._alloc = cc::system_allocator;
+    }
+
     growing_writer& operator=(growing_writer&& rhs) noexcept;
 
     ~growing_writer();
@@ -42,6 +49,7 @@ struct growing_writer
 
 private:
     phi::command_stream_writer _writer;
+    cc::allocator* _alloc;
 };
 
 }


### PR DESCRIPTION
- Add optional debug name arg to all resource creation methods
    - Add `Context::set_debug_name`
- Add allocator support to `Frame` (optional arg for `make_frame`)
- Remove some unneccesary includes (`typed-geometry/tg.hh` in `Frame` header)
- Add option to omit automatic render target transitions in framebuffer builder
- Internal changes