### PR TITLE
make_argument overloads, span arg to upload_texture_data, less headers

### DIFF
--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -163,13 +163,27 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 auto_prebuilt_argument Context::make_graphics_argument(const argument& arg)
 {
     auto const& info = arg._info.get();
-    return {prebuilt_argument{mBackend->createShaderView(info.srvs, info.uavs, info.samplers, false), phi::handle::null_resource, 0}, this};
+    return {prebuilt_argument{mBackend->createShaderView(info.srvs, info.uavs, info.samplers, false)}, this};
+}
+
+auto_prebuilt_argument Context::make_graphics_argument(cc::span<const phi::resource_view> srvs,
+                                                       cc::span<const phi::resource_view> uavs,
+                                                       cc::span<const phi::sampler_config> samplers)
+{
+    return {prebuilt_argument{mBackend->createShaderView(srvs, uavs, samplers, false)}, this};
 }
 
 auto_prebuilt_argument Context::make_compute_argument(const argument& arg)
 {
     auto const& info = arg._info.get();
-    return {prebuilt_argument{mBackend->createShaderView(info.srvs, info.uavs, info.samplers, true), phi::handle::null_resource, 0}, this};
+    return {prebuilt_argument{mBackend->createShaderView(info.srvs, info.uavs, info.samplers, true)}, this};
+}
+
+auto_prebuilt_argument Context::make_compute_argument(cc::span<const phi::resource_view> srvs,
+                                                      cc::span<const phi::resource_view> uavs,
+                                                      cc::span<const phi::sampler_config> samplers)
+{
+    return {prebuilt_argument{mBackend->createShaderView(srvs, uavs, samplers, true)}, this};
 }
 
 auto_graphics_pipeline_state Context::make_pipeline_state(const graphics_pass_info& gp_wrap, const framebuffer_info& fb)
@@ -765,4 +779,19 @@ void Context::free_compute_sv(cc::hash_t hash) { mCacheComputeSVs.free(hash, mGp
 auto_buffer pr::Context::make_upload_buffer_for_texture(const texture& tex, unsigned num_mips, const char* debug_name)
 {
     return make_upload_buffer(calculate_texture_upload_size(tex, num_mips), 0, debug_name);
+}
+
+unsigned pr::Context::calculate_texture_upload_size(const texture &texture, unsigned num_mips) const
+{
+    return calculate_texture_upload_size({texture.info.width, texture.info.height, int(texture.info.depth_or_array_size)}, texture.info.fmt, num_mips);
+}
+
+unsigned pr::Context::calculate_texture_upload_size(int width, format fmt, unsigned num_mips) const
+{
+    return calculate_texture_upload_size({width, 1, 1}, fmt, num_mips);
+}
+
+unsigned pr::Context::calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips) const
+{
+    return calculate_texture_upload_size({size.width, size.height, 1}, fmt, num_mips);
 }

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -128,7 +128,7 @@ public:
 
     /// uploads texture data correctly to a destination texture respecting rowwise alignment
     /// expects an appropriately sized upload buffer (see Context::calculate_texture_upload_size)
-    void upload_texture_data(std::byte const* texture_data, buffer const& upload_buffer, texture const& dest_texture);
+    void upload_texture_data(cc::span<std::byte const> texture_data, buffer const& upload_buffer, texture const& dest_texture);
 
     //
     // raw phi commands

--- a/src/phantasm-renderer/argument.cc
+++ b/src/phantasm-renderer/argument.cc
@@ -53,10 +53,10 @@ void pr::argument::fill_default_uav(phi::resource_view& new_rv, const pr::textur
 
 pr::auto_prebuilt_argument pr::argument_builder::make_graphics()
 {
-    return {prebuilt_argument{_parent->get_backend().createShaderView(_srvs, _uavs, _samplers, false), phi::handle::null_resource, 0}, _parent};
+    return {prebuilt_argument{_parent->get_backend().createShaderView(_srvs, _uavs, _samplers, false)}, _parent};
 }
 
 pr::auto_prebuilt_argument pr::argument_builder::make_compute()
 {
-    return {prebuilt_argument{_parent->get_backend().createShaderView(_srvs, _uavs, _samplers, true), phi::handle::null_resource, 0}, _parent};
+    return {prebuilt_argument{_parent->get_backend().createShaderView(_srvs, _uavs, _samplers, true)}, _parent};
 }

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <clean-core/vector.hh>
+#include <clean-core/alloc_vector.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 
@@ -182,8 +182,6 @@ private:
 struct prebuilt_argument
 {
     phi::handle::shader_view _sv = phi::handle::null_shader_view;
-    phi::handle::resource _cbv = phi::handle::null_resource;
-    unsigned _cbv_offset = 0;
 };
 
 using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, false>;
@@ -280,17 +278,17 @@ public:
 
 public:
     friend class Context;
-    argument_builder(Context* parent) : _parent(parent)
+    argument_builder(Context* parent, cc::allocator* temp_alloc) : _parent(parent)
     {
-        _srvs.reserve(16);
-        _uavs.reserve(16);
-        _samplers.reserve(8);
+        _srvs.reset_reserve(temp_alloc, 16);
+        _uavs.reset_reserve(temp_alloc, 16);
+        _samplers.reset_reserve(temp_alloc, 8);
     }
     Context* const _parent;
 
-    cc::vector<phi::resource_view> _srvs;
-    cc::vector<phi::resource_view> _uavs;
-    cc::vector<phi::sampler_config> _samplers;
+    cc::alloc_vector<phi::resource_view> _srvs;
+    cc::alloc_vector<phi::resource_view> _uavs;
+    cc::alloc_vector<phi::sampler_config> _samplers;
 };
 
 }

--- a/src/phantasm-renderer/common/circular_buffer.hh
+++ b/src/phantasm-renderer/common/circular_buffer.hh
@@ -2,8 +2,6 @@
 
 #include <cstddef>
 
-#include <rich-log/log.hh>
-
 #include <clean-core/move.hh>
 #include <clean-core/new.hh>
 #include <clean-core/utility.hh>

--- a/src/phantasm-renderer/common/single_cache.hh
+++ b/src/phantasm-renderer/common/single_cache.hh
@@ -6,9 +6,7 @@
 #include <clean-core/typedefs.hh>
 #include <clean-core/vector.hh>
 
-#include <rich-log/log.hh>
-
-#include <phantasm-hardware-interface/types.hh>
+#include <phantasm-hardware-interface/handles.hh>
 
 #include <phantasm-renderer/fwd.hh>
 
@@ -59,6 +57,7 @@ public:
         elem.required_gpu_epoch = current_cpu_epoch;
     }
 
+    /// destroys all elements that are not currently referenced (CPU) or in flight (GPU)
     template <class F>
     void cull_all(gpu_epoch_t current_gpu_epoch, F&& destroy_func)
     {


### PR DESCRIPTION
- Add make_graphics/compute_argument overloads from spans of resource views
- Use span<byte const> for Frame::upload_texture_data and add bounds checks
- Add temp allocator support for argument_builder
- Clean up unused fields in resource types
- Cut down includes in headers