### PR TITLE
free_deferred

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -21,7 +21,11 @@ public:
     CompiledFrame(CompiledFrame const&) = delete;
     CompiledFrame& operator=(CompiledFrame const&) = delete;
     CompiledFrame(CompiledFrame&& rhs) noexcept
-      : parent(rhs.parent), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables)), present_after_submit_swapchain(rhs.present_after_submit_swapchain)
+      : parent(rhs.parent),
+        cmdlist(rhs.cmdlist),
+        freeables(cc::move(rhs.freeables)),
+        deferred_free_resources(cc::move(rhs.deferred_free_resources)),
+        present_after_submit_swapchain(rhs.present_after_submit_swapchain)
     {
         rhs.parent = nullptr;
     }
@@ -34,6 +38,7 @@ public:
             parent = rhs.parent;
             cmdlist = rhs.cmdlist;
             freeables = cc::move(rhs.freeables);
+            deferred_free_resources = cc::move(rhs.deferred_free_resources);
             present_after_submit_swapchain = rhs.present_after_submit_swapchain;
             rhs.parent = nullptr;
         }
@@ -45,8 +50,16 @@ public:
 
 private:
     friend class Context;
-    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::alloc_vector<freeable_cached_obj>&& freeables, phi::handle::swapchain present_after_submit_sc)
-      : parent(parent), cmdlist(cmdlist), freeables(cc::move(freeables)), present_after_submit_swapchain(present_after_submit_sc)
+    CompiledFrame(Context* parent,
+                  phi::handle::command_list cmdlist,
+                  cc::alloc_vector<freeable_cached_obj>&& freeables,
+                  cc::alloc_vector<phi::handle::resource> deferred_free_resources,
+                  phi::handle::swapchain present_after_submit_sc)
+      : parent(parent),
+        cmdlist(cmdlist),
+        freeables(cc::move(freeables)),
+        deferred_free_resources(cc::move(deferred_free_resources)),
+        present_after_submit_swapchain(present_after_submit_sc)
     {
     }
 
@@ -55,6 +68,7 @@ private:
     Context* parent = nullptr;
     phi::handle::command_list cmdlist = phi::handle::null_command_list;
     cc::alloc_vector<freeable_cached_obj> freeables;
+    cc::alloc_vector<phi::handle::resource> deferred_free_resources;
     phi::handle::swapchain present_after_submit_swapchain = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -755,6 +755,11 @@ unsigned pr::Context::calculate_texture_upload_size(const texture& texture, unsi
     return calculate_texture_upload_size({texture.info.width, texture.info.height, int(texture.info.depth_or_array_size)}, texture.info.fmt, num_mips);
 }
 
+unsigned Context::calculate_texture_upload_size(const render_target& target) const
+{
+    return calculate_texture_upload_size({target.info.width, target.info.height, int(target.info.array_size)}, target.info.format, 1);
+}
+
 unsigned pr::Context::calculate_texture_upload_size(int width, format fmt, unsigned num_mips) const
 {
     return calculate_texture_upload_size({width, 1, 1}, fmt, num_mips);

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -6,8 +6,8 @@
 
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/config.hh>
-#include <phantasm-hardware-interface/detail/byte_util.hh>
-#include <phantasm-hardware-interface/detail/format_size.hh>
+#include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/util.hh>
 
 #include <phantasm-renderer/CompiledFrame.hh>

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -144,7 +144,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     {
         auto lg = std::lock_guard(mMutexShaderCompilation); // unsynced, mutex: compilation
-        bin = mShaderCompiler.compile_binary(code.data(), entrypoint.data(), sc_target, sc_output);
+        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output);
     }
 
     if (bin.data == nullptr)

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -228,11 +228,13 @@ public:
 
     /// map a buffer created on the upload or readback heap in order to access it on CPU
     /// a buffer can be mapped multiple times at once
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
+    /// begin and end specify the range of the mapping in bytes, end == -1 being the entire width
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int begin = 0, int end = -1);
 
     /// unmap a buffer previously mapped using map_buffer
     /// a buffer can be destroyed while mapped
-    void unmap_buffer(buffer const& buffer);
+    /// begin and end specify the range of CPU-side modified data in bytes, end == -1 being the entire width
+    void unmap_buffer(buffer const& buffer, int begin = 0, int end = -1);
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer_raw(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0);

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -344,6 +344,7 @@ public:
     unsigned calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(int width, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(texture const& texture, unsigned num_mips = 1) const;
+    unsigned calculate_texture_upload_size(render_target const& target) const;
 
     /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
     /// ex. use case: copying a render target to a readback buffer, then reading the pixel at this offset

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -267,11 +267,6 @@ public:
     /// block on CPU until a fence reaches a given value
     void wait_fence_cpu(fence const& fence, uint64_t wait_value);
 
-    /// signal a fence to a given value from a specified GPU queue
-    void signal_fence_gpu(fence const& fence, uint64_t new_value, queue_type queue);
-    /// block on a specified GPU queue until a fence reaches a given value
-    void wait_fence_gpu(fence const& fence, uint64_t wait_value, queue_type queue);
-
     /// read the current value of a fence
     [[nodiscard]] uint64_t get_fence_value(fence const& fence);
 
@@ -407,10 +402,10 @@ public:
     pr::backend get_backend_type() const { return mBackendType; }
 
     /// uint64 incremented on every submit, always greater or equal to GPU
-    gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker.get_current_epoch_cpu(); }
+    gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker._current_epoch_cpu; }
 
     /// uint64 incremented after every finished commandlist, GPU timeline, always less or equal to CPU
-    gpu_epoch_t get_current_gpu_epoch() const { return mGpuEpochTracker.get_current_epoch_gpu(); }
+    gpu_epoch_t get_current_gpu_epoch() const { return mGpuEpochTracker._cached_epoch_gpu; }
 
 public:
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -228,13 +228,15 @@ public:
 
     /// map a buffer created on the upload or readback heap in order to access it on CPU
     /// a buffer can be mapped multiple times at once
-    /// begin and end specify the range of the mapping in bytes, end == -1 being the entire width
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int begin = 0, int end = -1);
+    /// begin and end specify the range of CPU-side read data in bytes, end == -1 being the entire width
+    /// NOTE: begin > 0 does not add an offset to the returned pointer
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int invalidate_begin = 0, int invalidate_end = -1);
 
     /// unmap a buffer previously mapped using map_buffer
     /// a buffer can be destroyed while mapped
+    /// on non-desktop it might be required to unmap upload buffers for the writes to become visible
     /// begin and end specify the range of CPU-side modified data in bytes, end == -1 being the entire width
-    void unmap_buffer(buffer const& buffer, int begin = 0, int end = -1);
+    void unmap_buffer(buffer const& buffer, int flush_begin = 0, int flush_end = -1);
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer_raw(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0);

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -207,7 +207,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
     CC_ASSERT(dest_texture.info.depth_or_array_size == 1 && "array upload unimplemented");
     CC_ASSERT(upload_buffer.info.heap == resource_heap::upload && "buffer is not an upload buffer");
 
-    auto const bytes_per_pixel = phi::detail::format_size_bytes(dest_texture.info.fmt);
+    auto const bytes_per_pixel = phi::util::get_format_size_bytes(dest_texture.info.fmt);
     auto const use_d3d12_per_row_alingment = mCtx->get_backend_type() == pr::backend::d3d12;
     auto* const upload_buffer_map = mCtx->map_buffer(upload_buffer);
 
@@ -232,7 +232,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
 
         // MIP maps are 256-byte aligned per row in d3d12
         if (use_d3d12_per_row_alingment)
-            mip_row_stride_bytes = phi::mem::align_up(mip_row_stride_bytes, 256);
+            mip_row_stride_bytes = phi::util::align_up(mip_row_stride_bytes, 256);
 
         auto const mip_offset_bytes = mip_row_stride_bytes * command.dest_height;
         accumulated_offset_bytes += mip_offset_bytes;

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -6,8 +6,8 @@
 #include <clean-core/utility.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
-#include <phantasm-hardware-interface/detail/byte_util.hh>
-#include <phantasm-hardware-interface/detail/format_size.hh>
+#include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 
 #include <phantasm-renderer/Context.hh>
 #include <phantasm-renderer/common/log.hh>

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.cc
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.cc
@@ -1,6 +1,5 @@
 #include "gpu_epoch_tracker.hh"
 
-
 #include <clean-core/assert.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.cc
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.cc
@@ -1,22 +1,16 @@
 #include "gpu_epoch_tracker.hh"
 
 #include <clean-core/assert.hh>
+#include <clean-core/span.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
 
 void pr::gpu_epoch_tracker::initialize(phi::Backend* backend)
 {
-    _backend = backend;
     _fence = backend->createFence();
     CC_ASSERT(backend->getFenceValue(_fence) == 0 && "invalid fence value on init");
 }
 
-void pr::gpu_epoch_tracker::destroy() { _backend->free(cc::span{_fence}); }
+void pr::gpu_epoch_tracker::destroy(phi::Backend* backend) { backend->free(cc::span{_fence}); }
 
-void pr::gpu_epoch_tracker::increment_epoch()
-{
-    _backend->signalFenceGPU(_fence, _current_epoch_cpu, phi::queue_type::direct); // GPU starts catching up to current epoch
-    ++_current_epoch_cpu;                                                          // new epoch begins
-}
-
-pr::gpu_epoch_t pr::gpu_epoch_tracker::get_current_epoch_gpu() const { return _backend->getFenceValue(_fence); }
+pr::gpu_epoch_t pr::gpu_epoch_tracker::get_current_epoch_gpu(phi::Backend* backend) const { return backend->getFenceValue(_fence); }

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.hh
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.hh
@@ -13,22 +13,17 @@ using gpu_epoch_t = uint64_t;
 // internally synchronized
 struct gpu_epoch_tracker
 {
-public:
     void initialize(phi::Backend* backend);
-    void destroy();
-
-    /// increments CPU epoch, signals direct queue to CPU epoch
-    void increment_epoch();
+    void destroy(phi::Backend* backend);
 
     /// returns the epoch that is current on the CPU
     gpu_epoch_t get_current_epoch_cpu() const { return _current_epoch_cpu; }
 
     /// returns the epoch that has been reached on the GPU (<= CPU)
-    gpu_epoch_t get_current_epoch_gpu() const;
+    gpu_epoch_t get_current_epoch_gpu(phi::Backend* backend) const;
 
-private:
-    phi::Backend* _backend = nullptr;
     gpu_epoch_t _current_epoch_cpu = 1; // start 1 ahead of GPU
+    gpu_epoch_t _cached_epoch_gpu = 0;  // cached, always <= real GPU
     phi::handle::fence _fence;
 };
 }

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -3,7 +3,7 @@
 #include <clean-core/typedefs.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
-#include <phantasm-hardware-interface/detail/trivial_capped_vector.hh>
+#include <phantasm-hardware-interface/common/container/trivial_capped_vector.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -40,7 +40,7 @@ struct graphics_pass_info_data
     bool has_root_consts = false;
     phi::detail::trivial_capped_vector<phi::vertex_attribute_info, 8> vertex_attributes;
     phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
-    phi::detail::trivial_capped_vector<cc::hash_t, 5> shader_hashes;
+    phi::detail::trivial_capped_vector<cc::hash_t, phi::limits::num_graphics_shader_stages> shader_hashes;
 };
 
 struct compute_pass_info_data

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.cc
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.cc
@@ -24,7 +24,7 @@ void pr::deferred_destruction_queue::free_range(pr::Context& ctx, cc::span<const
     free_all_pending(ctx);
     if (res_range.size() > 0)
     {
-        pending_res_new.push_back_span(res_range);
+        pending_res_new.push_back_range(res_range);
         // PR_LOG("free, OLD: {}, NEW: {}, cpu: {}", gpu_epoch_old, gpu_epoch_new, latest_new_cpu);
     }
 }

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.cc
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.cc
@@ -1,0 +1,79 @@
+#include "deferred_destruction_queue.hh"
+
+#include <clean-core/utility.hh>
+
+#include <phantasm-hardware-interface/Backend.hh>
+
+#include <phantasm-renderer/Context.hh>
+
+void pr::deferred_destruction_queue::free(pr::Context& ctx, phi::handle::shader_view sv)
+{
+    free_all_pending(ctx);
+    pending_svs_new.push_back(sv);
+}
+
+void pr::deferred_destruction_queue::free(pr::Context& ctx, phi::handle::resource res)
+{
+    free_all_pending(ctx);
+    pending_res_new.push_back(res);
+}
+
+void pr::deferred_destruction_queue::free_range(pr::Context& ctx, cc::span<const phi::handle::resource> res_range)
+{
+    free_all_pending(ctx);
+    pending_res_new.push_back_span(res_range);
+}
+
+void pr::deferred_destruction_queue::initialize(cc::allocator* alloc, unsigned num_reserved_svs, unsigned num_reserved_res)
+{
+    pending_svs_old.reset_reserve(alloc, num_reserved_svs);
+    pending_svs_new.reset_reserve(alloc, num_reserved_svs);
+    pending_res_old.reset_reserve(alloc, num_reserved_res);
+    pending_res_new.reset_reserve(alloc, num_reserved_res);
+}
+
+void pr::deferred_destruction_queue::destroy(pr::Context& ctx)
+{
+    ctx.get_backend().freeRange(pending_svs_old);
+    ctx.get_backend().freeRange(pending_svs_new);
+    ctx.get_backend().freeRange(pending_res_old);
+    ctx.get_backend().freeRange(pending_res_new);
+    pending_svs_old = {};
+    pending_svs_new = {};
+    pending_res_old = {};
+    pending_res_new = {};
+}
+
+unsigned pr::deferred_destruction_queue::free_all_pending(pr::Context& ctx)
+{
+    auto const epoch_cpu = ctx.get_current_cpu_epoch();
+    auto const epoch_gpu = ctx.get_current_gpu_epoch();
+
+    unsigned num_freed = 0;
+    if (epoch_gpu >= gpu_epoch_old)
+    {
+        // can free old
+        if (pending_svs_old.size() > 0)
+        {
+            num_freed += unsigned(pending_svs_old.size());
+            ctx.get_backend().freeRange(pending_svs_old);
+        }
+        if (pending_res_old.size() > 0)
+        {
+            num_freed += unsigned(pending_res_old.size());
+            ctx.get_backend().freeRange(pending_res_old);
+        }
+
+        cc::swap(pending_svs_old, pending_svs_new);
+        cc::swap(pending_res_old, pending_res_new);
+        pending_svs_new.clear();
+        pending_res_new.clear();
+
+        gpu_epoch_old = gpu_epoch_new;
+    }
+
+    CC_ASSERT(epoch_cpu >= gpu_epoch_new && ">400 year overflow or programmer error");
+    gpu_epoch_new = epoch_cpu;
+
+    return num_freed;
+}

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.hh
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <clean-core/alloc_vector.hh>
+
+#include <phantasm-hardware-interface/handles.hh>
+
+#include <phantasm-renderer/fwd.hh>
+
+namespace pr
+{
+/// persistent queue of (PHI) resources pending destruction
+/// keeps track of GPU epochs and automatically frees older resources when enqueueing
+struct deferred_destruction_queue
+{
+    void free(pr::Context& ctx, phi::handle::shader_view sv);
+    void free(pr::Context& ctx, phi::handle::resource res);
+    void free_range(pr::Context& ctx, cc::span<phi::handle::resource const> res_range);
+
+    unsigned free_all_pending(pr::Context& ctx);
+
+    void initialize(cc::allocator* alloc, unsigned num_reserved_svs = 128, unsigned num_reserved_res = 128);
+    void destroy(pr::Context& ctx);
+
+private:
+    gpu_epoch_t gpu_epoch_old = 0;
+    gpu_epoch_t gpu_epoch_new = 0;
+
+    cc::alloc_vector<phi::handle::shader_view> pending_svs_old;
+    cc::alloc_vector<phi::handle::shader_view> pending_svs_new;
+    cc::alloc_vector<phi::handle::resource> pending_res_old;
+    cc::alloc_vector<phi::handle::resource> pending_res_new;
+};
+}

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -117,12 +117,8 @@ public:
         return *this;
     }
 
-private:
-    friend class raii::Frame;
     cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
-private:
-    friend class Context;
     hashable_storage<graphics_pass_info_data> _storage;
     cc::capped_vector<phi::arg::graphics_shader, 5> _shaders;
 };
@@ -242,12 +238,8 @@ public:
         return *this;
     }
 
-private:
-    friend class raii::Frame;
     cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
-private:
-    friend class Context;
     hashable_storage<phi::arg::framebuffer_config> _storage;
 };
 

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -234,7 +234,7 @@ public:
     /// Add a depth render target based on format only
     framebuffer_info& depth(pr::format format)
     {
-        _storage.get().add_depth_target(format);
+        _storage.get().set_depth_target(format);
         return *this;
     }
 

--- a/src/phantasm-renderer/reflection/vertex_attributes.hh
+++ b/src/phantasm-renderer/reflection/vertex_attributes.hh
@@ -110,6 +110,8 @@ struct vertex_visitor
 template <class VertT>
 [[nodiscard]] auto get_vertex_attributes()
 {
+    static_assert(rf::is_introspectable<VertT>, "Vertex type must be introspectable for automatic attribute extraction."
+                                                "Provide `template <class In> constexpr void introspect(In&& insp, Vertex& vert);'");
     detail::vertex_visitor<VertT> visitor;
     VertT* volatile dummy_ptr = nullptr;
     rf::do_introspect(visitor, *dummy_ptr);

--- a/src/phantasm-renderer/reflection/vertex_attributes.hh
+++ b/src/phantasm-renderer/reflection/vertex_attributes.hh
@@ -80,7 +80,7 @@ constexpr phi::format to_attribute_format()
 
     else
     {
-        static_assert(sizeof(T) == 0, "incompatbile attribute type");
+        static_assert(sizeof(T) == 0, "incompatible attribute type");
         return af::rgba32f;
     }
 }


### PR DESCRIPTION
- Added `Context::free_deferred` to free GPU resources once they are no longer in flight
- Added `Frame::free_deferred_after_submit` to do the same for GPU resources that will still be used by that frame
- Internal changes and adaptations to phi API