### PR TITLE
free_deferred, GPU buffer alignment test

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -21,7 +21,11 @@ public:
     CompiledFrame(CompiledFrame const&) = delete;
     CompiledFrame& operator=(CompiledFrame const&) = delete;
     CompiledFrame(CompiledFrame&& rhs) noexcept
-      : parent(rhs.parent), cmdlist(rhs.cmdlist), freeables(cc::move(rhs.freeables)), present_after_submit_swapchain(rhs.present_after_submit_swapchain)
+      : parent(rhs.parent),
+        cmdlist(rhs.cmdlist),
+        freeables(cc::move(rhs.freeables)),
+        deferred_free_resources(cc::move(rhs.deferred_free_resources)),
+        present_after_submit_swapchain(rhs.present_after_submit_swapchain)
     {
         rhs.parent = nullptr;
     }
@@ -34,6 +38,7 @@ public:
             parent = rhs.parent;
             cmdlist = rhs.cmdlist;
             freeables = cc::move(rhs.freeables);
+            deferred_free_resources = cc::move(rhs.deferred_free_resources);
             present_after_submit_swapchain = rhs.present_after_submit_swapchain;
             rhs.parent = nullptr;
         }
@@ -45,8 +50,16 @@ public:
 
 private:
     friend class Context;
-    CompiledFrame(Context* parent, phi::handle::command_list cmdlist, cc::alloc_vector<freeable_cached_obj>&& freeables, phi::handle::swapchain present_after_submit_sc)
-      : parent(parent), cmdlist(cmdlist), freeables(cc::move(freeables)), present_after_submit_swapchain(present_after_submit_sc)
+    CompiledFrame(Context* parent,
+                  phi::handle::command_list cmdlist,
+                  cc::alloc_vector<freeable_cached_obj>&& freeables,
+                  cc::alloc_vector<phi::handle::resource> deferred_free_resources,
+                  phi::handle::swapchain present_after_submit_sc)
+      : parent(parent),
+        cmdlist(cmdlist),
+        freeables(cc::move(freeables)),
+        deferred_free_resources(cc::move(deferred_free_resources)),
+        present_after_submit_swapchain(present_after_submit_sc)
     {
     }
 
@@ -55,6 +68,7 @@ private:
     Context* parent = nullptr;
     phi::handle::command_list cmdlist = phi::handle::null_command_list;
     cc::alloc_vector<freeable_cached_obj> freeables;
+    cc::alloc_vector<phi::handle::resource> deferred_free_resources;
     phi::handle::swapchain present_after_submit_swapchain = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -755,6 +755,11 @@ unsigned pr::Context::calculate_texture_upload_size(const texture& texture, unsi
     return calculate_texture_upload_size({texture.info.width, texture.info.height, int(texture.info.depth_or_array_size)}, texture.info.fmt, num_mips);
 }
 
+unsigned Context::calculate_texture_upload_size(const render_target& target) const
+{
+    return calculate_texture_upload_size({target.info.width, target.info.height, int(target.info.array_size)}, target.info.format, 1);
+}
+
 unsigned pr::Context::calculate_texture_upload_size(int width, format fmt, unsigned num_mips) const
 {
     return calculate_texture_upload_size({width, 1, 1}, fmt, num_mips);

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -436,14 +436,7 @@ void Context::present(swapchain const& sc)
 
 void Context::flush() { mBackend->flushGPU(); }
 
-bool Context::flush(gpu_epoch_t epoch)
-{
-    if (mGpuEpochTracker._cached_epoch_gpu >= epoch)
-        return false;
 
-    flush();
-    return true;
-}
 
 bool Context::start_capture() { return mBackend->startForcedDiagnosticCapture(); }
 bool Context::stop_capture() { return mBackend->endForcedDiagnosticCapture(); }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -6,8 +6,8 @@
 
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/config.hh>
-#include <phantasm-hardware-interface/detail/byte_util.hh>
-#include <phantasm-hardware-interface/detail/format_size.hh>
+#include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/util.hh>
 
 #include <phantasm-renderer/CompiledFrame.hh>

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -144,7 +144,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     {
         auto lg = std::lock_guard(mMutexShaderCompilation); // unsynced, mutex: compilation
-        bin = mShaderCompiler.compile_binary(code.data(), entrypoint.data(), sc_target, sc_output);
+        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output);
     }
 
     if (bin.data == nullptr)

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -437,7 +437,6 @@ void Context::present(swapchain const& sc)
 void Context::flush() { mBackend->flushGPU(); }
 
 
-
 bool Context::start_capture() { return mBackend->startForcedDiagnosticCapture(); }
 bool Context::stop_capture() { return mBackend->endForcedDiagnosticCapture(); }
 

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -228,11 +228,13 @@ public:
 
     /// map a buffer created on the upload or readback heap in order to access it on CPU
     /// a buffer can be mapped multiple times at once
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer);
+    /// begin and end specify the range of the mapping in bytes, end == -1 being the entire width
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int begin = 0, int end = -1);
 
     /// unmap a buffer previously mapped using map_buffer
     /// a buffer can be destroyed while mapped
-    void unmap_buffer(buffer const& buffer);
+    /// begin and end specify the range of CPU-side modified data in bytes, end == -1 being the entire width
+    void unmap_buffer(buffer const& buffer, int begin = 0, int end = -1);
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer_raw(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0);

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -344,6 +344,7 @@ public:
     unsigned calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(int width, format fmt, unsigned num_mips = 1) const;
     unsigned calculate_texture_upload_size(texture const& texture, unsigned num_mips = 1) const;
+    unsigned calculate_texture_upload_size(render_target const& target) const;
 
     /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
     /// ex. use case: copying a render target to a readback buffer, then reading the pixel at this offset

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -267,11 +267,6 @@ public:
     /// block on CPU until a fence reaches a given value
     void wait_fence_cpu(fence const& fence, uint64_t wait_value);
 
-    /// signal a fence to a given value from a specified GPU queue
-    void signal_fence_gpu(fence const& fence, uint64_t new_value, queue_type queue);
-    /// block on a specified GPU queue until a fence reaches a given value
-    void wait_fence_gpu(fence const& fence, uint64_t wait_value, queue_type queue);
-
     /// read the current value of a fence
     [[nodiscard]] uint64_t get_fence_value(fence const& fence);
 
@@ -407,10 +402,10 @@ public:
     pr::backend get_backend_type() const { return mBackendType; }
 
     /// uint64 incremented on every submit, always greater or equal to GPU
-    gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker.get_current_epoch_cpu(); }
+    gpu_epoch_t get_current_cpu_epoch() const { return mGpuEpochTracker._current_epoch_cpu; }
 
     /// uint64 incremented after every finished commandlist, GPU timeline, always less or equal to CPU
-    gpu_epoch_t get_current_gpu_epoch() const { return mGpuEpochTracker.get_current_epoch_gpu(); }
+    gpu_epoch_t get_current_gpu_epoch() const { return mGpuEpochTracker._cached_epoch_gpu; }
 
 public:
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -228,13 +228,15 @@ public:
 
     /// map a buffer created on the upload or readback heap in order to access it on CPU
     /// a buffer can be mapped multiple times at once
-    /// begin and end specify the range of the mapping in bytes, end == -1 being the entire width
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int begin = 0, int end = -1);
+    /// begin and end specify the range of CPU-side read data in bytes, end == -1 being the entire width
+    /// NOTE: begin > 0 does not add an offset to the returned pointer
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int invalidate_begin = 0, int invalidate_end = -1);
 
     /// unmap a buffer previously mapped using map_buffer
     /// a buffer can be destroyed while mapped
+    /// on non-desktop it might be required to unmap upload buffers for the writes to become visible
     /// begin and end specify the range of CPU-side modified data in bytes, end == -1 being the entire width
-    void unmap_buffer(buffer const& buffer, int begin = 0, int end = -1);
+    void unmap_buffer(buffer const& buffer, int flush_begin = 0, int flush_end = -1);
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer_raw(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0);

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -223,7 +223,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
     // for (auto a = 0u; a < img_size.array_size; ++a)
     {
         command.dest_array_index = 0u; // a;
-        command.source_offset = accumulated_offset_bytes;
+        command.source_offset_bytes = accumulated_offset_bytes;
 
         mWriter.add_command(command);
 
@@ -238,7 +238,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
         accumulated_offset_bytes += mip_offset_bytes;
 
         CC_ASSERT(texture_data.size() >= mip_row_size_bytes * command.dest_height && "texture source data too small");
-        rowwise_copy(texture_data, upload_buffer_map + command.source_offset, mip_row_stride_bytes, mip_row_size_bytes, command.dest_height);
+        rowwise_copy(texture_data, upload_buffer_map + command.source_offset_bytes, mip_row_stride_bytes, mip_row_size_bytes, command.dest_height);
     }
 
     mCtx->unmap_buffer(upload_buffer);

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -207,7 +207,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
     CC_ASSERT(dest_texture.info.depth_or_array_size == 1 && "array upload unimplemented");
     CC_ASSERT(upload_buffer.info.heap == resource_heap::upload && "buffer is not an upload buffer");
 
-    auto const bytes_per_pixel = phi::detail::format_size_bytes(dest_texture.info.fmt);
+    auto const bytes_per_pixel = phi::util::get_format_size_bytes(dest_texture.info.fmt);
     auto const use_d3d12_per_row_alingment = mCtx->get_backend_type() == pr::backend::d3d12;
     auto* const upload_buffer_map = mCtx->map_buffer(upload_buffer);
 
@@ -232,7 +232,7 @@ void raii::Frame::upload_texture_data(cc::span<const std::byte> texture_data, co
 
         // MIP maps are 256-byte aligned per row in d3d12
         if (use_d3d12_per_row_alingment)
-            mip_row_stride_bytes = phi::mem::align_up(mip_row_stride_bytes, 256);
+            mip_row_stride_bytes = phi::util::align_up(mip_row_stride_bytes, 256);
 
         auto const mip_offset_bytes = mip_row_stride_bytes * command.dest_height;
         accumulated_offset_bytes += mip_offset_bytes;

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -6,8 +6,8 @@
 #include <clean-core/utility.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
-#include <phantasm-hardware-interface/detail/byte_util.hh>
-#include <phantasm-hardware-interface/detail/format_size.hh>
+#include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 
 #include <phantasm-renderer/Context.hh>
 #include <phantasm-renderer/common/log.hh>

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -36,7 +36,7 @@ void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, co
     std::memcpy(dcmd.shader_arguments.data(), mCmd.shader_arguments.data(), sizeof(dcmd.shader_arguments));
     dcmd.pipeline_state = mCmd.pipeline_state;
     dcmd.indirect_argument_buffer = argument_buffer.res.handle;
-    dcmd.argument_buffer_offset = arg_buffer_offset;
+    dcmd.argument_buffer_offset_bytes = arg_buffer_offset;
     dcmd.num_arguments = num_args;
     dcmd.vertex_buffer = vertex_buffer.res.handle;
     dcmd.index_buffer = phi::handle::null_resource;

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.cc
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.cc
@@ -1,6 +1,5 @@
 #include "gpu_epoch_tracker.hh"
 
-
 #include <clean-core/assert.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.cc
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.cc
@@ -1,22 +1,16 @@
 #include "gpu_epoch_tracker.hh"
 
 #include <clean-core/assert.hh>
+#include <clean-core/span.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
 
 void pr::gpu_epoch_tracker::initialize(phi::Backend* backend)
 {
-    _backend = backend;
     _fence = backend->createFence();
     CC_ASSERT(backend->getFenceValue(_fence) == 0 && "invalid fence value on init");
 }
 
-void pr::gpu_epoch_tracker::destroy() { _backend->free(cc::span{_fence}); }
+void pr::gpu_epoch_tracker::destroy(phi::Backend* backend) { backend->free(cc::span{_fence}); }
 
-void pr::gpu_epoch_tracker::increment_epoch()
-{
-    _backend->signalFenceGPU(_fence, _current_epoch_cpu, phi::queue_type::direct); // GPU starts catching up to current epoch
-    ++_current_epoch_cpu;                                                          // new epoch begins
-}
-
-pr::gpu_epoch_t pr::gpu_epoch_tracker::get_current_epoch_gpu() const { return _backend->getFenceValue(_fence); }
+pr::gpu_epoch_t pr::gpu_epoch_tracker::get_current_epoch_gpu(phi::Backend* backend) const { return backend->getFenceValue(_fence); }

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.hh
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.hh
@@ -13,22 +13,17 @@ using gpu_epoch_t = uint64_t;
 // internally synchronized
 struct gpu_epoch_tracker
 {
-public:
     void initialize(phi::Backend* backend);
-    void destroy();
-
-    /// increments CPU epoch, signals direct queue to CPU epoch
-    void increment_epoch();
+    void destroy(phi::Backend* backend);
 
     /// returns the epoch that is current on the CPU
     gpu_epoch_t get_current_epoch_cpu() const { return _current_epoch_cpu; }
 
     /// returns the epoch that has been reached on the GPU (<= CPU)
-    gpu_epoch_t get_current_epoch_gpu() const;
+    gpu_epoch_t get_current_epoch_gpu(phi::Backend* backend) const;
 
-private:
-    phi::Backend* _backend = nullptr;
     gpu_epoch_t _current_epoch_cpu = 1; // start 1 ahead of GPU
+    gpu_epoch_t _cached_epoch_gpu = 0;  // cached, always <= real GPU
     phi::handle::fence _fence;
 };
 }

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -25,7 +25,7 @@ public:
         std::memset(_storage, 0, sizeof(_storage)); // memset padding and unitialized bytes to 0
 
         if constexpr (!std::is_trivially_constructible_v<T, void>)
-            new (&_storage) T(); // call default ctor
+            new (cc::placement_new, &_storage) T(); // call default ctor
     }
 
     // with the established guarantees, hashing and comparison are trivial

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -3,7 +3,7 @@
 #include <clean-core/typedefs.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
-#include <phantasm-hardware-interface/common/container/trivial_capped_vector.hh>
+#include <phantasm-hardware-interface/common/container/flat_vector.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 
@@ -26,11 +26,11 @@ struct freeable_cached_obj
 // for economic reasons, SRVs, UAVs and Samplers are limited for cache-access shader views
 struct shader_view_info
 {
-    phi::detail::trivial_capped_vector<phi::resource_view, 4> srvs;
-    phi::detail::trivial_capped_vector<phi::resource_view, 4> uavs;
-    phi::detail::trivial_capped_vector<uint64_t, 4> srv_guids;
-    phi::detail::trivial_capped_vector<uint64_t, 4> uav_guids;
-    phi::detail::trivial_capped_vector<phi::sampler_config, 2> samplers;
+    phi::flat_vector<phi::resource_view, 4> srvs;
+    phi::flat_vector<phi::resource_view, 4> uavs;
+    phi::flat_vector<uint64_t, 4> srv_guids;
+    phi::flat_vector<uint64_t, 4> uav_guids;
+    phi::flat_vector<phi::sampler_config, 2> samplers;
 };
 
 struct graphics_pass_info_data
@@ -38,15 +38,15 @@ struct graphics_pass_info_data
     phi::pipeline_config graphics_config = {};
     unsigned vertex_size_bytes = 0;
     bool has_root_consts = false;
-    phi::detail::trivial_capped_vector<phi::vertex_attribute_info, 8> vertex_attributes;
-    phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
-    phi::detail::trivial_capped_vector<cc::hash_t, phi::limits::num_graphics_shader_stages> shader_hashes;
+    phi::flat_vector<phi::vertex_attribute_info, 8> vertex_attributes;
+    phi::flat_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
+    phi::flat_vector<cc::hash_t, phi::limits::num_graphics_shader_stages> shader_hashes;
 };
 
 struct compute_pass_info_data
 {
     bool has_root_consts = false;
-    phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
+    phi::flat_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
     cc::hash_t shader_hash;
 };
 }

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -3,7 +3,7 @@
 #include <clean-core/typedefs.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
-#include <phantasm-hardware-interface/detail/trivial_capped_vector.hh>
+#include <phantasm-hardware-interface/common/container/trivial_capped_vector.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -40,7 +40,7 @@ struct graphics_pass_info_data
     bool has_root_consts = false;
     phi::detail::trivial_capped_vector<phi::vertex_attribute_info, 8> vertex_attributes;
     phi::detail::trivial_capped_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;
-    phi::detail::trivial_capped_vector<cc::hash_t, 5> shader_hashes;
+    phi::detail::trivial_capped_vector<cc::hash_t, phi::limits::num_graphics_shader_stages> shader_hashes;
 };
 
 struct compute_pass_info_data

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.cc
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.cc
@@ -24,7 +24,7 @@ void pr::deferred_destruction_queue::free_range(pr::Context& ctx, cc::span<const
     free_all_pending(ctx);
     if (res_range.size() > 0)
     {
-        pending_res_new.push_back_span(res_range);
+        pending_res_new.push_back_range(res_range);
         // PR_LOG("free, OLD: {}, NEW: {}, cpu: {}", gpu_epoch_old, gpu_epoch_new, latest_new_cpu);
     }
 }

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.cc
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.cc
@@ -1,0 +1,79 @@
+#include "deferred_destruction_queue.hh"
+
+#include <clean-core/utility.hh>
+
+#include <phantasm-hardware-interface/Backend.hh>
+
+#include <phantasm-renderer/Context.hh>
+
+void pr::deferred_destruction_queue::free(pr::Context& ctx, phi::handle::shader_view sv)
+{
+    free_all_pending(ctx);
+    pending_svs_new.push_back(sv);
+}
+
+void pr::deferred_destruction_queue::free(pr::Context& ctx, phi::handle::resource res)
+{
+    free_all_pending(ctx);
+    pending_res_new.push_back(res);
+}
+
+void pr::deferred_destruction_queue::free_range(pr::Context& ctx, cc::span<const phi::handle::resource> res_range)
+{
+    free_all_pending(ctx);
+    pending_res_new.push_back_span(res_range);
+}
+
+void pr::deferred_destruction_queue::initialize(cc::allocator* alloc, unsigned num_reserved_svs, unsigned num_reserved_res)
+{
+    pending_svs_old.reset_reserve(alloc, num_reserved_svs);
+    pending_svs_new.reset_reserve(alloc, num_reserved_svs);
+    pending_res_old.reset_reserve(alloc, num_reserved_res);
+    pending_res_new.reset_reserve(alloc, num_reserved_res);
+}
+
+void pr::deferred_destruction_queue::destroy(pr::Context& ctx)
+{
+    ctx.get_backend().freeRange(pending_svs_old);
+    ctx.get_backend().freeRange(pending_svs_new);
+    ctx.get_backend().freeRange(pending_res_old);
+    ctx.get_backend().freeRange(pending_res_new);
+    pending_svs_old = {};
+    pending_svs_new = {};
+    pending_res_old = {};
+    pending_res_new = {};
+}
+
+unsigned pr::deferred_destruction_queue::free_all_pending(pr::Context& ctx)
+{
+    auto const epoch_cpu = ctx.get_current_cpu_epoch();
+    auto const epoch_gpu = ctx.get_current_gpu_epoch();
+
+    unsigned num_freed = 0;
+    if (epoch_gpu >= gpu_epoch_old)
+    {
+        // can free old
+        if (pending_svs_old.size() > 0)
+        {
+            num_freed += unsigned(pending_svs_old.size());
+            ctx.get_backend().freeRange(pending_svs_old);
+        }
+        if (pending_res_old.size() > 0)
+        {
+            num_freed += unsigned(pending_res_old.size());
+            ctx.get_backend().freeRange(pending_res_old);
+        }
+
+        cc::swap(pending_svs_old, pending_svs_new);
+        cc::swap(pending_res_old, pending_res_new);
+        pending_svs_new.clear();
+        pending_res_new.clear();
+
+        gpu_epoch_old = gpu_epoch_new;
+    }
+
+    CC_ASSERT(epoch_cpu >= gpu_epoch_new && ">400 year overflow or programmer error");
+    gpu_epoch_new = epoch_cpu;
+
+    return num_freed;
+}

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.hh
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <clean-core/alloc_vector.hh>
+
+#include <phantasm-hardware-interface/handles.hh>
+
+#include <phantasm-renderer/fwd.hh>
+
+namespace pr
+{
+/// persistent queue of (PHI) resources pending destruction
+/// keeps track of GPU epochs and automatically frees older resources when enqueueing
+struct deferred_destruction_queue
+{
+    void free(pr::Context& ctx, phi::handle::shader_view sv);
+    void free(pr::Context& ctx, phi::handle::resource res);
+    void free_range(pr::Context& ctx, cc::span<phi::handle::resource const> res_range);
+
+    unsigned free_all_pending(pr::Context& ctx);
+
+    void initialize(cc::allocator* alloc, unsigned num_reserved_svs = 128, unsigned num_reserved_res = 128);
+    void destroy(pr::Context& ctx);
+
+private:
+    gpu_epoch_t gpu_epoch_old = 0;
+    gpu_epoch_t gpu_epoch_new = 0;
+
+    cc::alloc_vector<phi::handle::shader_view> pending_svs_old;
+    cc::alloc_vector<phi::handle::shader_view> pending_svs_new;
+    cc::alloc_vector<phi::handle::resource> pending_res_old;
+    cc::alloc_vector<phi::handle::resource> pending_res_new;
+};
+}

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -117,12 +117,8 @@ public:
         return *this;
     }
 
-private:
-    friend class raii::Frame;
     cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
-private:
-    friend class Context;
     hashable_storage<graphics_pass_info_data> _storage;
     cc::capped_vector<phi::arg::graphics_shader, 5> _shaders;
 };
@@ -242,12 +238,8 @@ public:
         return *this;
     }
 
-private:
-    friend class raii::Frame;
     cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
-private:
-    friend class Context;
     hashable_storage<phi::arg::framebuffer_config> _storage;
 };
 

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -234,7 +234,7 @@ public:
     /// Add a depth render target based on format only
     framebuffer_info& depth(pr::format format)
     {
-        _storage.get().add_depth_target(format);
+        _storage.get().set_depth_target(format);
         return *this;
     }
 

--- a/src/phantasm-renderer/reflection/gpu_buffer_alignment.cc
+++ b/src/phantasm-renderer/reflection/gpu_buffer_alignment.cc
@@ -1,0 +1,130 @@
+#include "gpu_buffer_alignment.hh"
+
+#include <clean-core/bits.hh>
+
+#include <phantasm-hardware-interface/util.hh>
+
+#include <phantasm-renderer/common/log.hh>
+
+void pr::BufferAlignmentVisitor::printConflictField()
+{
+    PR_LOG_WARN("struct unsuitable for GPU usage, conflicting field: {}, reason: {}, size: {}, offset: C++: {}, HLSL: {}", first_conflict.name,
+                pr::conflicting_buffer_field::get_reason_literal(first_conflict.reason), first_conflict.size, first_conflict.offset_in_cpp,
+                first_conflict.offset_in_hlsl);
+}
+
+void pr::BufferAlignmentVisitor::performCheck(unsigned field_size_bytes, unsigned offset_cpp, const char* name)
+{
+    testOrderConsistency(offset_cpp, field_size_bytes, name);
+
+    // no further checks, but C++ ordering is highest priority
+    if (!valid)
+        return;
+
+    // fields that are too small cannot be placed correctly
+    if (field_size_bytes < 4)
+    {
+        valid = false;
+        first_conflict.name = name;
+        first_conflict.reason = conflicting_buffer_field::e_too_small;
+        first_conflict.size = field_size_bytes;
+        first_conflict.offset_in_cpp = 0;
+        first_conflict.offset_in_hlsl = 0;
+        return;
+    }
+
+    auto f_add_field = [this, &name](unsigned offset_cpp, unsigned size_bytes) -> bool {
+        // get offset in HLSL
+        unsigned const offset_hlsl = phi::util::get_hlsl_constant_buffer_offset(head_bytes_hlsl, size_bytes);
+
+        // error: HLSL misalignment
+        if (offset_hlsl != offset_cpp)
+        {
+            valid = false;
+            first_conflict.name = name;
+            first_conflict.reason = conflicting_buffer_field::e_hlsl_misaligned;
+            first_conflict.size = size_bytes;
+            first_conflict.offset_in_cpp = offset_cpp;
+            first_conflict.offset_in_hlsl = offset_hlsl;
+            return false;
+        }
+
+        head_bytes_hlsl = offset_hlsl + size_bytes;
+        return true;
+    };
+
+    // split field into 16 byte chunks (float4)
+    while (field_size_bytes > 16)
+    {
+        if (!f_add_field(offset_cpp, 16))
+            return;
+
+        field_size_bytes -= 16;
+        offset_cpp += 16;
+    }
+
+    // epilogue / non-oversized field
+    f_add_field(offset_cpp, field_size_bytes);
+}
+
+void pr::BufferAlignmentVisitor::performCheckArray(unsigned elem_size_bytes, unsigned array_size, unsigned offset_cpp, const char* name)
+{
+    testOrderConsistency(offset_cpp, elem_size_bytes * array_size, name);
+
+    // no further checks, but C++ ordering is highest priority
+    if (!valid)
+        return;
+
+    // array elements smaller than a multiple of 16B are up-padded on GPU, this C array will inevitably misalign
+    if (cc::mod_pow2(elem_size_bytes, 16u) != 0)
+    {
+        valid = false;
+        first_conflict.name = name;
+        first_conflict.reason = conflicting_buffer_field::e_array_elem_padding;
+        first_conflict.size = elem_size_bytes;
+        first_conflict.offset_in_cpp = 0;
+        first_conflict.offset_in_hlsl = 0;
+        return;
+    }
+
+    // get offset in HLSL for the array start
+    unsigned const array_start_offset_hlsl = phi::util::get_hlsl_constant_buffer_offset(head_bytes_hlsl, elem_size_bytes);
+
+    // error: HLSL misalignment
+    if (array_start_offset_hlsl != offset_cpp)
+    {
+        valid = false;
+        first_conflict.name = name;
+        first_conflict.reason = conflicting_buffer_field::e_hlsl_misaligned;
+        first_conflict.size = elem_size_bytes;
+        first_conflict.offset_in_cpp = offset_cpp;
+        first_conflict.offset_in_hlsl = array_start_offset_hlsl;
+        return;
+    }
+
+    // this can be a simple multiply since elem_size_bytes % 16 == 0
+    // adding array_size float4's to the buffer
+    head_bytes_hlsl = array_start_offset_hlsl + elem_size_bytes * array_size;
+}
+
+void pr::BufferAlignmentVisitor::testOrderConsistency(unsigned new_offset_cpp, unsigned new_field_size_bytes, const char* new_field_name)
+{
+    // error: cpp order inconsistent
+    if (new_offset_cpp < last_cpp_offset)
+    {
+        // can be argued to always be a programmer error, not a data error
+        // CC_ASSERT(false && "C++ offsets inconsistent, are the calls in introspect ordered correctly?");
+        valid = false;
+
+        if (first_conflict.reason != conflicting_buffer_field::e_cpp_wrong_order)
+        {
+            first_conflict.name = new_field_name;
+            first_conflict.reason = conflicting_buffer_field::e_cpp_wrong_order;
+            first_conflict.size = new_field_size_bytes;
+            first_conflict.offset_in_cpp = new_offset_cpp;
+            first_conflict.offset_in_hlsl = 0;
+        }
+    }
+
+    last_cpp_offset = new_offset_cpp;
+}

--- a/src/phantasm-renderer/reflection/gpu_buffer_alignment.hh
+++ b/src/phantasm-renderer/reflection/gpu_buffer_alignment.hh
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cstdint>
+
+#include <reflector/introspect.hh>
+
+namespace pr
+{
+struct conflicting_buffer_field;
+
+/// test a C++ struct for correct HLSL constant buffer alignment
+template <class BufferT>
+[[nodiscard]] bool test_gpu_buffer_alignment(conflicting_buffer_field* out_first_conflict = nullptr, bool verbose = false);
+
+
+struct conflicting_buffer_field
+{
+    enum e_reason
+    {
+        e_hlsl_misaligned,    // the field aligns differently in HLSL than it does in C++
+        e_cpp_wrong_order,    // the field was visited in the wrong order in the introspect() function
+        e_too_large,          // the field is larger than 16B and cannot be placed in a HLSL constant buffer
+        e_too_small,          // the field is smaller than 4B (could be placed, but would behave incorrectly)
+        e_array_elem_padding, // the field is an array with elements that are not a multiple of 16B (which will get padded on GPU)
+    };
+
+    char const* name;
+    e_reason reason;
+    unsigned size;
+    unsigned offset_in_cpp;
+    unsigned offset_in_hlsl;
+
+    static constexpr char const* get_reason_literal(conflicting_buffer_field::e_reason reason);
+};
+
+
+struct BufferAlignmentVisitor
+{
+    bool valid = true;
+    conflicting_buffer_field first_conflict;
+
+    template <class T>
+    void operator()(T const& ref, char const* name)
+    {
+        auto const offset_cpp = uint32_t(reinterpret_cast<size_t>(&ref));
+        performCheck(sizeof(T), offset_cpp, name);
+    }
+
+    template <class ElemT, size_t N>
+    void operator()(ElemT const (&ref)[N], char const* name)
+    {
+        auto const offset_cpp = uint32_t(reinterpret_cast<size_t>(&ref));
+        performCheckArray(sizeof(ElemT), N, offset_cpp, name);
+    }
+
+    void printConflictField();
+
+private:
+    void performCheck(unsigned field_size_bytes, unsigned offset_cpp, char const* name);
+
+    void performCheckArray(unsigned elem_size_bytes, unsigned array_size, unsigned offset_cpp, char const* name);
+
+    void testOrderConsistency(unsigned new_offset_cpp, unsigned new_field_size_bytes, char const* new_field_name);
+
+    unsigned head_bytes_hlsl = 0;
+    unsigned last_cpp_offset = 0;
+};
+
+template <class BufferT>
+bool test_gpu_buffer_alignment(conflicting_buffer_field* out_first_conflict, bool verbose)
+{
+    static_assert(std::is_trivially_copyable_v<BufferT>, "test_gpu_buffer_alignment - buffer is not trivially copyable");
+
+    BufferAlignmentVisitor visitor;
+    BufferT* volatile dummy_ptr = nullptr;
+    rf::do_introspect(visitor, *dummy_ptr);
+
+    if (visitor.valid)
+    {
+        return true;
+    }
+    else
+    {
+        if (out_first_conflict)
+            *out_first_conflict = visitor.first_conflict;
+
+        if (verbose)
+            visitor.printConflictField();
+
+        return false;
+    }
+}
+
+constexpr const char* conflicting_buffer_field::get_reason_literal(conflicting_buffer_field::e_reason reason)
+{
+    switch (reason)
+    {
+    case conflicting_buffer_field::e_too_large:
+        return "too large";
+    case conflicting_buffer_field::e_too_small:
+        return "too small";
+    case conflicting_buffer_field::e_cpp_wrong_order:
+        return "introspect order inconsistent";
+    case conflicting_buffer_field::e_hlsl_misaligned:
+        return "HLSL misaligned";
+    case conflicting_buffer_field::e_array_elem_padding:
+        return "array elements not a multiple of 16B";
+    }
+    return "unknown reason";
+}
+}

--- a/src/phantasm-renderer/reflection/vertex_attributes.hh
+++ b/src/phantasm-renderer/reflection/vertex_attributes.hh
@@ -110,6 +110,8 @@ struct vertex_visitor
 template <class VertT>
 [[nodiscard]] auto get_vertex_attributes()
 {
+    static_assert(rf::is_introspectable<VertT>, "Vertex type must be introspectable for automatic attribute extraction."
+                                                "Provide `template <class In> constexpr void introspect(In&& insp, Vertex& vert);'");
     detail::vertex_visitor<VertT> visitor;
     VertT* volatile dummy_ptr = nullptr;
     rf::do_introspect(visitor, *dummy_ptr);

--- a/src/phantasm-renderer/reflection/vertex_attributes.hh
+++ b/src/phantasm-renderer/reflection/vertex_attributes.hh
@@ -80,7 +80,7 @@ constexpr phi::format to_attribute_format()
 
     else
     {
-        static_assert(sizeof(T) == 0, "incompatbile attribute type");
+        static_assert(sizeof(T) == 0, "incompatible attribute type");
         return af::rgba32f;
     }
 }


### PR DESCRIPTION
- Added `Context::free_deferred` to free GPU resources once they are no longer in flight
    - Added `Frame::free_deferred_after_submit` to do the same for GPU resources that will still be used by that frame
- Added `test_gpu_buffer_alignment` to test if a C++ buffer will correctly align with its HLSL constant buffer equivalent
    - Requires rf introspect
    - limited support for nested types / non-C arrays
- Adapted to changed phi fence API **(breaking)**
    - breakage: removed `Context::wait_fence_gpu`, `Context::signal_fence_gpu`, this is now part of cmdlist submits
    - Fixed vulkan GPU epoch tracking
- Added advanced buffer mapping invalidate/flush controls
- Internal changes and adaptations to phi API