### PR TITLE
Rework Lifetime Rules

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.cc
+++ b/src/phantasm-renderer/CompiledFrame.cc
@@ -1,11 +1,1 @@
 #include "CompiledFrame.hh"
-
-#include "Context.hh"
-
-void pr::CompiledFrame::_destroy()
-{
-    if (parent != nullptr)
-    {
-        parent->discard(cc::move(*this));
-    }
-}

--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -10,65 +10,70 @@ namespace pr
 {
 class Context;
 
-/**
- * A CompiledFrame is a compiled command list ready for submission
- */
+/// A compiled command list ready for submission, as received from Context::compile(frame)
+/// move-only, must be submitted or discarded via the Context before destruction
 class CompiledFrame
 {
-    // move-only type
 public:
     CompiledFrame() = default;
+
+    /// whether this is properly constructed (and not moved-from)
+    bool is_valid() const { return _valid; }
+
     CompiledFrame(CompiledFrame const&) = delete;
     CompiledFrame& operator=(CompiledFrame const&) = delete;
+
     CompiledFrame(CompiledFrame&& rhs) noexcept
-      : parent(rhs.parent),
-        cmdlist(rhs.cmdlist),
-        freeables(cc::move(rhs.freeables)),
-        deferred_free_resources(cc::move(rhs.deferred_free_resources)),
-        present_after_submit_swapchain(rhs.present_after_submit_swapchain)
+      : _valid(rhs._valid),
+        _cmdlist(rhs._cmdlist),
+        _freeables(cc::move(rhs._freeables)),
+        _deferred_free_resources(cc::move(rhs._deferred_free_resources)),
+        _present_after_submit_swapchain(rhs._present_after_submit_swapchain)
     {
-        rhs.parent = nullptr;
+        rhs.invalidate();
     }
 
     CompiledFrame& operator=(CompiledFrame&& rhs) noexcept
     {
         if (this != &rhs)
         {
-            _destroy();
-            parent = rhs.parent;
-            cmdlist = rhs.cmdlist;
-            freeables = cc::move(rhs.freeables);
-            deferred_free_resources = cc::move(rhs.deferred_free_resources);
-            present_after_submit_swapchain = rhs.present_after_submit_swapchain;
-            rhs.parent = nullptr;
+            // if this is already valid, this move would delete a submission-ready command list
+            CC_ASSERT(!is_valid() && "all compiled frames must be submitted or discarded via the Context");
+
+            _valid = rhs._valid;
+            _cmdlist = rhs._cmdlist;
+            _freeables = cc::move(rhs._freeables);
+            _deferred_free_resources = cc::move(rhs._deferred_free_resources);
+            _present_after_submit_swapchain = rhs._present_after_submit_swapchain;
+
+            rhs.invalidate();
         }
 
         return *this;
     }
 
-    ~CompiledFrame() { _destroy(); }
+    ~CompiledFrame() { CC_ASSERT(!is_valid() && "all compiled frames must be submitted or discarded via the Context"); }
 
 private:
     friend class Context;
-    CompiledFrame(Context* parent,
-                  phi::handle::command_list cmdlist,
+    CompiledFrame(phi::handle::command_list cmdlist,
                   cc::alloc_vector<freeable_cached_obj>&& freeables,
-                  cc::alloc_vector<phi::handle::resource> deferred_free_resources,
+                  cc::alloc_vector<phi::handle::resource>&& deferred_free_resources,
                   phi::handle::swapchain present_after_submit_sc)
-      : parent(parent),
-        cmdlist(cmdlist),
-        freeables(cc::move(freeables)),
-        deferred_free_resources(cc::move(deferred_free_resources)),
-        present_after_submit_swapchain(present_after_submit_sc)
+      : _valid(true),
+        _cmdlist(cmdlist),
+        _freeables(cc::move(freeables)),
+        _deferred_free_resources(cc::move(deferred_free_resources)),
+        _present_after_submit_swapchain(present_after_submit_sc)
     {
     }
 
-    void _destroy();
+    void invalidate() { _valid = false; }
 
-    Context* parent = nullptr;
-    phi::handle::command_list cmdlist = phi::handle::null_command_list;
-    cc::alloc_vector<freeable_cached_obj> freeables;
-    cc::alloc_vector<phi::handle::resource> deferred_free_resources;
-    phi::handle::swapchain present_after_submit_swapchain = phi::handle::null_swapchain;
+    bool _valid = false;
+    phi::handle::command_list _cmdlist = phi::handle::null_command_list;
+    cc::alloc_vector<freeable_cached_obj> _freeables;
+    cc::alloc_vector<phi::handle::resource> _deferred_free_resources;
+    phi::handle::swapchain _present_after_submit_swapchain = phi::handle::null_swapchain;
 };
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -387,7 +387,7 @@ gpu_epoch_t Context::submit(CompiledFrame&& frame)
 
         {
             // unsynced, mutex: submission
-            auto const lg = std::lock_guard(mMutexSubmission);
+            auto const lg = std::lock_guard<std::mutex>(mMutexSubmission);
             mBackend->submit(cc::span{frame.cmdlist}, phi::queue_type::direct, {}, cc::span{signal_op});
         }
 

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -266,9 +266,9 @@ void Context::write_to_buffer_raw(const buffer& buffer, cc::span<std::byte const
     int const map_begin = int(offset_in_buffer);
     int const map_end = int(offset_in_buffer + data.size_bytes());
 
-    std::byte* const map = map_buffer(buffer, map_begin, map_end);
+    std::byte* const map = map_buffer(buffer, 0, 0); // invalidate nothing
     std::memcpy(map + offset_in_buffer, data.data(), data.size_bytes());
-    unmap_buffer(buffer, map_begin, map_end);
+    unmap_buffer(buffer, map_begin, map_end); // flush the whole range
 }
 
 void Context::read_from_buffer_raw(const buffer& buffer, cc::span<std::byte> out_data, size_t offset_in_buffer)
@@ -279,9 +279,9 @@ void Context::read_from_buffer_raw(const buffer& buffer, cc::span<std::byte> out
     int const map_begin = int(offset_in_buffer);
     int const map_end = int(offset_in_buffer + out_data.size_bytes());
 
-    std::byte const* const map = map_buffer(buffer, map_begin, map_end);
+    std::byte const* const map = map_buffer(buffer, map_begin, map_end); // invalidate the whole range
     std::memcpy(out_data.data(), map + offset_in_buffer, out_data.size_bytes());
-    unmap_buffer(buffer, map_begin, map_end);
+    unmap_buffer(buffer, 0, 0); // flush nothing
 }
 
 void Context::signal_fence_cpu(const fence& fence, uint64_t new_value) { mBackend->signalFenceCPU(fence.handle, new_value); }

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -157,8 +157,9 @@ public:
     //   must not be in flight on GPU during call
     //
 
-    /// free a resource that was unlocked from automatic management
+    /// free a resource that was disowned from automatic management
     void free_untyped(phi::handle::resource resource);
+
     void free_untyped(raw_resource const& resource) { free_untyped(resource.handle); }
 
     /// free a buffer
@@ -178,6 +179,19 @@ public:
     }
     void free(query_range const& q);
 
+    void free_range(cc::span<phi::handle::resource const> res_range);
+    void free_range(cc::span<prebuilt_argument const> arg_range);
+    void free_range(cc::span<phi::handle::shader_view const> sv_range);
+
+    /// convenience to free multiple (disowned) resources
+    template <class... Res>
+    void free_multiple_resources(Res&&... res_args)
+    {
+        // any resource still wrapped in the auto_ wrapper wouldn't have a .res member (but instead .data.res)
+        phi::handle::resource flat_handles[] = {res_args.res.handle...};
+        free_range(flat_handles);
+    }
+
     //
     // deferred freeing
     //   destroy a resource in the future once currently pending GPU operations are done
@@ -196,6 +210,7 @@ public:
     /// free raw PHI resources once no longer in flight
     void free_deferred(phi::handle::resource res);
     void free_deferred(phi::handle::shader_view sv);
+    void free_range_deferred(cc::span<phi::handle::resource const> res_range);
 
     //
     // cache freeing
@@ -343,6 +358,11 @@ public:
     /// returns whether the epoch was reached on the GPU
     bool is_gpu_epoch_reached(gpu_epoch_t epoch) const { return mGpuEpochTracker._cached_epoch_gpu >= epoch; }
 
+    /// "shuts down" the context: calls flush(), no longer accepts frame submits, and
+    /// no longer asserts on non-disowned resources getting destroyed
+    /// NOTE: this NOT the same as Context::destroy()
+    void flush_and_shutdown();
+
     //
     // cache management
     //
@@ -416,6 +436,7 @@ public:
     /// ex. use case: copying a render target to a readback buffer, then reading the pixel at this offset
     unsigned calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const;
 
+    bool is_shutting_down() const { return mIsShuttingDown.load(std::memory_order_relaxed); }
 
     //
     // miscellaneous
@@ -461,10 +482,12 @@ public:
 
     ~Context() { destroy(); }
 
+    /// initializes the context
     void initialize(backend type, cc::allocator* alloc = cc::system_allocator);
     void initialize(backend type, phi::backend_config const& config, cc::allocator* alloc = cc::system_allocator);
     void initialize(phi::Backend* backend, cc::allocator* alloc = cc::system_allocator);
 
+    /// destroys the context
     void destroy();
 
     bool is_initialized() const { return mBackend != nullptr; }
@@ -472,19 +495,17 @@ public:
 public:
     // deleted overrides
 
-    // auto_ types are not to be freed manually, only free unlocked types
-    template <class T, bool Cached>
-    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free(auto_destroyer<T, Cached> const&) = delete;
+    // auto_ types are not to be freed manually, only free disowned types
+    template <class T, auto_mode M>
+    [[deprecated("auto_ types must not be explicitly freed, use .disown() for manual management")]] void free(auto_destroyer<T, M> const&) = delete;
 
-    // auto_ types are not to be freed manually, only free unlocked types
-    template <class T, bool Cached>
-    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_to_cache(auto_destroyer<T, Cached> const&)
-        = delete;
+    // auto_ types are not to be freed manually, only free disowned types
+    template <class T, auto_mode M>
+    [[deprecated("auto_ types must not be explicitly freed, use .disown() for manual management")]] void free_to_cache(auto_destroyer<T, M> const&) = delete;
 
-    // auto_ types are not to be freed manually, only free unlocked types
-    template <class T, bool Cached>
-    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_deferred(auto_destroyer<T, Cached> const&)
-        = delete;
+    // auto_ types are not to be freed manually, only free disowned types
+    template <class T, auto_mode M>
+    [[deprecated("auto_ types must not be explicitly freed, use .disown() for manual management")]] void free_deferred(auto_destroyer<T, M> const&) = delete;
 
 private:
     //
@@ -556,6 +577,7 @@ private:
     std::mutex mMutexShaderCompilation;
     gpu_epoch_tracker mGpuEpochTracker;
     std::atomic<uint64_t> mResourceGUID = {1}; // GUID 0 is invalid
+    std::atomic<bool> mIsShuttingDown = {false};
     deferred_destruction_queue mDeferredQueue;
 
     // caches (have dtors, members must be below backend ptr)

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -91,7 +91,7 @@ public:
     }
 
 
-    /// create a shader from binary data
+    /// create a shader from binary data (only hashes the data)
     [[nodiscard]] auto_shader_binary make_shader(cc::span<cc::byte const> data, pr::shader stage);
     /// create a shader by compiling it live from text
     [[nodiscard]] auto_shader_binary make_shader(cc::string_view code, cc::string_view entrypoint, pr::shader stage);

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -383,10 +383,10 @@ raii::Framebuffer raii::Frame::buildFramebuffer(const phi::cmd::begin_render_pas
     framebuffer_info fb_info;
 
     for (auto const& target : bcmd.render_targets)
-        fb_info.target(target.rv.pixel_format);
+        fb_info.target(target.rv.texture_info.pixel_format);
 
     if (bcmd.depth_target.rv.resource.is_valid())
-        fb_info.depth(bcmd.depth_target.rv.pixel_format);
+        fb_info.depth(bcmd.depth_target.rv.texture_info.pixel_format);
 
     if (has_blendstate_overrides)
     {

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -261,7 +261,7 @@ void raii::Frame::auto_upload_texture_data(cc::span<const std::byte> texture_dat
     CC_ASSERT(dest_texture.info.depth_or_array_size == 1 && "array upload unimplemented");
 
     // automatically create and free_deferred a matching upload buffer
-    pr::buffer upload_buffer = mCtx->make_upload_buffer_for_texture(dest_texture, 1, "Frame::upload_texture_data - internal").unlock();
+    pr::buffer upload_buffer = mCtx->make_upload_buffer_for_texture(dest_texture, 1, "Frame::upload_texture_data - internal").disown();
 
     upload_texture_data(texture_data, upload_buffer, dest_texture);
 

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -432,8 +432,8 @@ void raii::Frame::framebufferOnSortByPSO(unsigned num_drawcalls)
 
 phi::handle::pipeline_state raii::Frame::framebufferAcquireGraphicsPSO(const graphics_pass_info& gp, const framebuffer_info& fb, int fb_inferred_num_samples)
 {
-    CC_ASSERT((fb_inferred_num_samples == -1
-              || fb_inferred_num_samples == gp._storage.get().graphics_config.samples) && "graphics_pass_info has incorrect amount of samples configured");
+    CC_ASSERT((fb_inferred_num_samples == -1 || fb_inferred_num_samples == gp._storage.get().graphics_config.samples)
+              && "graphics_pass_info has incorrect amount of samples configured");
     auto const combined_hash = cc::hash_combine(gp.get_hash(), fb.get_hash());
     auto const res = mCtx->acquire_graphics_pso(combined_hash, gp, fb);
     mFreeables.push_back({freeable_cached_obj::graphics_pso, combined_hash});

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -205,6 +205,7 @@ public:
 
     Frame& operator=(Frame&& rhs) noexcept;
 
+    Frame() = default;
     ~Frame() { internalDestroy(); }
 
     // private
@@ -258,7 +259,7 @@ private:
 
     // members
 private:
-    Context* mCtx;
+    Context* mCtx = nullptr;
     growing_writer mWriter;
     phi::cmd::transition_resources mPendingTransitionCommand;
     cc::alloc_vector<freeable_cached_obj> mFreeables;

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -135,6 +135,13 @@ public:
     /// (deferred freeing it afterwards)
     void auto_upload_texture_data(cc::span<std::byte const> texture_data, texture const& dest_texture);
 
+    void upload_texture_subresource(cc::span<std::byte const> texture_data,
+                                    unsigned row_size_bytes,
+                                    buffer const& upload_buffer,
+                                    unsigned buffer_offset_bytes,
+                                    texture const& dest_texture,
+                                    unsigned dest_subres_index);
+
     /// free a buffer once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(buffer const& buf) { free_deferred_after_submit(buf.res.handle); }
     /// free a texture once no longer in flight AFTER this frame was submitted/discarded

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -185,7 +185,7 @@ public:
     [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] framebuffer_builder build_framebuffer() && = delete;
 
     template <class T, auto_mode M>
-    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_deferred_after_submit(auto_destroyer<T, M> const&)
+    [[deprecated("auto_ types must not be explicitly freed, use .disown() for manual management")]] void free_deferred_after_submit(auto_destroyer<T, M> const&)
         = delete;
 
 public:

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -126,9 +126,14 @@ public:
     //
     // specials
 
-    /// uploads texture data correctly to a destination texture respecting rowwise alignment
-    /// expects an appropriately sized upload buffer (see Context::calculate_texture_upload_size)
+    /// uploads texture data correctly to a destination texture, respecting rowwise alignment
+    /// transition cmd + copy_buf_to_tex cmd
+    /// expects upload buffer with sufficient size (see Context::calculate_texture_upload_size)
     void upload_texture_data(cc::span<std::byte const> texture_data, buffer const& upload_buffer, texture const& dest_texture);
+
+    /// creates a suitable upload buffer and calls upload_texutre_data
+    /// (deferred freeing it afterwards)
+    void auto_upload_texture_data(cc::span<std::byte const> texture_data, texture const& dest_texture);
 
     /// free a buffer once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(buffer const& buf) { free_deferred_after_submit(buf.res.handle); }

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -184,8 +184,8 @@ public:
     [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] Framebuffer make_framebuffer(RTs const&...) && = delete;
     [[deprecated("pr::raii::Frame must stay alive while framebuffers are used")]] framebuffer_builder build_framebuffer() && = delete;
 
-    template <class T, bool Cached>
-    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_deferred_after_submit(auto_destroyer<T, Cached> const&)
+    template <class T, auto_mode M>
+    [[deprecated("auto_ types must not be explicitly freed, use .unlock() for manual management")]] void free_deferred_after_submit(auto_destroyer<T, M> const&)
         = delete;
 
 public:

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -153,10 +153,19 @@ public:
     }
 
     /// override the viewport (defaults to minimum of target sizes)
-    [[nodiscard]] framebuffer_builder& set_viewport(int w, int h)
+    [[nodiscard]] framebuffer_builder& set_viewport(int w, int h) { return this->set_viewport({w, h}); }
+
+    /// override the viewport (defaults to minimum of target sizes)
+    [[nodiscard]] framebuffer_builder& set_viewport(tg::isize2 size)
     {
-        _cmd.viewport = {w, h};
+        _cmd.viewport = size;
         _has_custom_viewport = true;
+        return *this;
+    }
+
+    [[nodiscard]] framebuffer_builder& set_viewport_offset(tg::ivec2 offset)
+    {
+        _cmd.viewport_offset = offset;
         return *this;
     }
 

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -14,6 +14,7 @@ void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer)
 
 void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer)
 {
+    CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
     CC_ASSERT(index_buffer.info.stride_bytes > 0 && "index buffer not strided");
     CC_ASSERT(index_buffer.info.stride_bytes <= 4 && "index buffer stride unusually large - switched up vertex and index buffer?");
     draw(vertex_buffer.res.handle, index_buffer.res.handle, index_buffer.info.size_bytes / index_buffer.info.stride_bytes);

--- a/src/phantasm-renderer/argument.cc
+++ b/src/phantasm-renderer/argument.cc
@@ -7,7 +7,7 @@
 void pr::argument::fill_default_srv(phi::resource_view& new_rv, const pr::texture& img, unsigned mip_start, unsigned mip_size)
 {
     new_rv.resource = img.res.handle;
-    new_rv.pixel_format = img.info.fmt;
+    new_rv.texture_info.pixel_format = img.info.fmt;
     new_rv.texture_info.mip_start = mip_start;
 
     if (mip_size != unsigned(-1))

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -184,7 +184,7 @@ struct prebuilt_argument
     phi::handle::shader_view _sv = phi::handle::null_shader_view;
 };
 
-using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, false>;
+using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, auto_mode::guard>;
 
 // builder, only received directly from Context, can grow indefinitely in size, not hashable
 struct argument_builder

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -98,6 +98,7 @@ public:
         fill_default_srv(new_rv, img, 0, unsigned(-1));
         _add_srv(new_rv, img.res.guid);
     }
+
     /// add a default-configured structured buffer SRV
     void add(buffer const& buffer)
     {
@@ -105,8 +106,10 @@ public:
         _add_srv(phi::resource_view::structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes),
                  buffer.res.guid);
     }
+
     /// add a default-configured 2D texture SRV
     void add(render_target const& rt) { _add_srv(phi::resource_view::tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1), rt.res.guid); }
+
     /// add a configured SRV
     void add(resource_view_info const& rvi) { _add_srv(rvi.rv, rvi.guid); }
 
@@ -117,6 +120,7 @@ public:
         fill_default_uav(new_rv, img, 0, unsigned(-1));
         _add_uav(new_rv, img.res.guid);
     }
+
     /// add a default-configured buffer UAV
     void add_mutable(buffer const& buffer)
     {
@@ -124,6 +128,7 @@ public:
         _add_uav(phi::resource_view::structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes),
                  buffer.res.guid);
     }
+
     /// add a default-configured 2D texture UAV
     void add_mutable(render_target const& rt)
     {

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -17,7 +17,7 @@ struct resource_view_info
 {
     resource_view_info& format(pr::format fmt)
     {
-        rv.pixel_format = fmt;
+        rv.texture_info.pixel_format = fmt;
         return *this;
     }
 

--- a/src/phantasm-renderer/common/growing_writer.cc
+++ b/src/phantasm-renderer/common/growing_writer.cc
@@ -1,7 +1,5 @@
 #include "growing_writer.hh"
 
-#include <cstdlib>
-
 pr::growing_writer::growing_writer(size_t initial_size, cc::allocator* alloc) : _alloc(alloc)
 {
     CC_CONTRACT(alloc != nullptr);
@@ -27,12 +25,4 @@ pr::growing_writer& pr::growing_writer::operator=(pr::growing_writer&& rhs) noex
 
 pr::growing_writer::~growing_writer() { _alloc->free(_writer.buffer()); }
 
-void pr::growing_writer::accomodate(size_t cmd_size)
-{
-    if (!_writer.can_accomodate(cmd_size))
-    {
-        size_t const new_size = (_writer.max_size() + cmd_size) << 1;
-        std::byte* const new_buffer = _alloc->realloc(_writer.buffer(), _writer.max_size(), new_size);
-        _writer.exchange_buffer(new_buffer, new_size);
-    }
-}
+

--- a/src/phantasm-renderer/common/growing_writer.cc
+++ b/src/phantasm-renderer/common/growing_writer.cc
@@ -24,5 +24,3 @@ pr::growing_writer& pr::growing_writer::operator=(pr::growing_writer&& rhs) noex
 }
 
 pr::growing_writer::~growing_writer() { _alloc->free(_writer.buffer()); }
-
-

--- a/src/phantasm-renderer/common/growing_writer.hh
+++ b/src/phantasm-renderer/common/growing_writer.hh
@@ -43,7 +43,15 @@ struct growing_writer
     size_t max_size() const { return _writer.max_size(); }
     bool is_empty() const { return _writer.empty(); }
 
-    void accomodate(size_t cmd_size);
+    void accomodate(size_t cmd_size)
+    {
+        if (!_writer.can_accomodate(cmd_size))
+        {
+            size_t const new_size = (_writer.max_size() + cmd_size) << 1;
+            std::byte* const new_buffer = _alloc->realloc(_writer.buffer(), _writer.max_size(), new_size);
+            _writer.exchange_buffer(new_buffer, new_size);
+        }
+    }
 
     phi::command_stream_writer& raw_writer() { return _writer; }
 

--- a/src/phantasm-renderer/common/growing_writer.hh
+++ b/src/phantasm-renderer/common/growing_writer.hh
@@ -9,6 +9,7 @@ namespace pr
 // naive growing writer
 struct growing_writer
 {
+    growing_writer() = default;
     growing_writer(size_t initial_size, cc::allocator* alloc = cc::system_allocator);
     growing_writer(growing_writer&& rhs) noexcept : _writer(rhs._writer), _alloc(rhs._alloc)
     {
@@ -57,7 +58,7 @@ struct growing_writer
 
 private:
     phi::command_stream_writer _writer;
-    cc::allocator* _alloc;
+    cc::allocator* _alloc = cc::system_allocator;
 };
 
 }

--- a/src/phantasm-renderer/common/hashable_storage.hh
+++ b/src/phantasm-renderer/common/hashable_storage.hh
@@ -29,9 +29,9 @@ public:
     }
 
     // with the established guarantees, hashing and comparison are trivial
-    void get_murmur(murmur_hash& out) const { murmurhash3_x64_128(_storage, sizeof(T), 0, out); }
+    void get_murmur(murmur_hash& out) const { murmurhash3_x64_128(_storage, sizeof(T), 31, out); }
 
-    cc::hash_t get_xxhash() const { return cc::hash_xxh3(cc::as_byte_span(_storage), 0); }
+    cc::hash_t get_xxhash() const { return cc::hash_xxh3(cc::as_byte_span(_storage), 31); }
 
     bool operator==(hashable_storage<T> const& rhs) const noexcept { return std::memcmp(_storage.value, rhs._storage, sizeof(_storage)) == 0; }
 

--- a/src/phantasm-renderer/detail/auto_destroyer.cc
+++ b/src/phantasm-renderer/detail/auto_destroyer.cc
@@ -8,6 +8,8 @@ void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::buf
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::render_target& v) { ctx->free_to_cache(v); }
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::texture& v) { ctx->free_to_cache(v); }
 
+bool pr::detail::auto_destroy_proxy::is_destroy_legal(pr::Context* ctx) { return ctx->is_shutting_down(); }
+
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::buffer& v) { ctx->free_untyped(v.res); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::render_target& v) { ctx->free_untyped(v.res); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::texture& v) { ctx->free_untyped(v.res); }

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -14,6 +14,8 @@ struct auto_destroy_proxy
     static void cache_deref(pr::Context* ctx, render_target const& v);
     static void cache_deref(pr::Context* ctx, texture const& v);
 
+    static bool is_destroy_legal(pr::Context* ctx);
+
     static void destroy(pr::Context* ctx, buffer const& v);
     static void destroy(pr::Context* ctx, render_target const& v);
     static void destroy(pr::Context* ctx, texture const& v);
@@ -26,10 +28,37 @@ struct auto_destroy_proxy
 };
 }
 
-template <class T, bool Cache>
+template <class T, auto_mode Mode>
 struct auto_destroyer
 {
     T data;
+
+    /// disable RAII management and receive the POD contents, which must now be manually freed
+    [[nodiscard]] T disown()
+    {
+        CC_ASSERT(parent != nullptr && "Attempted to disown an invalid auto_ type");
+        parent = nullptr;
+        return data;
+    }
+
+    /// free prematurely (to cache or not), invalid afterwards
+    void free()
+    {
+        if (parent != nullptr)
+        {
+            if constexpr (Mode == auto_mode::cache)
+            {
+                detail::auto_destroy_proxy::cache_deref(parent, data);
+            }
+            else if constexpr (Mode == auto_mode::destroy || Mode == auto_mode::guard)
+            {
+                // explicit call - also valid in guard mode
+                detail::auto_destroy_proxy::destroy(parent, data);
+            }
+
+            parent = nullptr;
+        }
+    }
 
     auto_destroyer() = default;
     auto_destroyer(T const& data, pr::Context* parent) : data(data), parent(parent) {}
@@ -49,16 +78,7 @@ struct auto_destroyer
 
     ~auto_destroyer() { _destroy(); }
 
-    /// disable RAII management and receive the POD contents, which must now be manually freed
-    [[nodiscard]] T const& unlock()
-    {
-        CC_ASSERT(parent != nullptr && "Attempted to unlock an invalid auto_ type");
-        parent = nullptr;
-        return data;
-    }
-
-    /// free prematurely (to cache or not), invalid afterwards
-    void free() { _destroy(); }
+    [[deprecated("renamed to .disown()")]] [[nodiscard]] T unlock() { return disown(); }
 
     operator T&() & { return data; }
     operator T const&() const& { return data; }
@@ -67,8 +87,8 @@ struct auto_destroyer
     [[deprecated("auto_ types are move-only")]] auto_destroyer& operator=(auto_destroyer const&) = delete;
 
     // force unlock from rvalue
-    [[deprecated("discarding auto_ type here would destroy contents, use .unlock()")]] operator T&() && = delete;
-    [[deprecated("discarding auto_ type here would destroy contents, use .unlock()")]] operator T const&() const&& = delete;
+    [[deprecated("discarding auto_ type here would destroy contents, use .disown()")]] operator T&() && = delete;
+    [[deprecated("discarding auto_ type here would destroy contents, use .disown()")]] operator T const&() const&& = delete;
 
 private:
     pr::Context* parent = nullptr;
@@ -77,13 +97,17 @@ private:
     {
         if (parent != nullptr)
         {
-            if constexpr (Cache)
+            if constexpr (Mode == auto_mode::cache)
             {
                 detail::auto_destroy_proxy::cache_deref(parent, data);
             }
-            else
+            else if constexpr (Mode == auto_mode::destroy)
             {
                 detail::auto_destroy_proxy::destroy(parent, data);
+            }
+            else if constexpr (Mode == auto_mode::guard)
+            {
+                CC_ASSERT(detail::auto_destroy_proxy::is_destroy_legal(parent) && "discarded auto_ type without .disown() (and before a context shutdown)");
             }
 
             parent = nullptr;

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -108,6 +108,10 @@ private:
             else if constexpr (Mode == auto_mode::guard)
             {
                 CC_ASSERT(detail::auto_destroy_proxy::is_destroy_legal(parent) && "discarded auto_ type without .disown() (and before a context shutdown)");
+
+                // guard-types also destroy, but only after the context is in shutdown mode (Context::flush_and_shutdown)
+                // (the only reason to destroy here is to avoid the PHI-level leak detection marking these as leaks)
+                detail::auto_destroy_proxy::destroy(parent, data);
             }
 
             parent = nullptr;

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -86,7 +86,7 @@ struct auto_destroyer
     [[deprecated("auto_ types are move-only")]] auto_destroyer(auto_destroyer const&) = delete;
     [[deprecated("auto_ types are move-only")]] auto_destroyer& operator=(auto_destroyer const&) = delete;
 
-    // force unlock from rvalue
+    // force disown from rvalue
     [[deprecated("discarding auto_ type here would destroy contents, use .disown()")]] operator T&() && = delete;
     [[deprecated("discarding auto_ type here would destroy contents, use .disown()")]] operator T const&() const&& = delete;
 

--- a/src/phantasm-renderer/fwd.hh
+++ b/src/phantasm-renderer/fwd.hh
@@ -16,7 +16,14 @@ namespace pr
 class Context;
 using gpu_epoch_t = uint64_t;
 
-template <class T, bool Cache>
+enum class auto_mode : uint8_t
+{
+    guard,   // assert that the resource was disowned
+    destroy, // destroy the resource
+    cache    // cache-dereference the resource
+};
+
+template <class T, auto_mode Cache>
 struct auto_destroyer;
 
 // resources
@@ -25,13 +32,13 @@ struct buffer;
 struct render_target;
 struct texture;
 
-using auto_buffer = auto_destroyer<buffer, false>;
-using auto_render_target = auto_destroyer<render_target, false>;
-using auto_texture = auto_destroyer<texture, false>;
+using auto_buffer = auto_destroyer<buffer, auto_mode::guard>;
+using auto_render_target = auto_destroyer<render_target, auto_mode::guard>;
+using auto_texture = auto_destroyer<texture, auto_mode::guard>;
 
-using cached_buffer = auto_destroyer<buffer, true>;
-using cached_render_target = auto_destroyer<render_target, true>;
-using cached_texture = auto_destroyer<texture, true>;
+using cached_buffer = auto_destroyer<buffer, auto_mode::cache>;
+using cached_render_target = auto_destroyer<render_target, auto_mode::cache>;
+using cached_texture = auto_destroyer<texture, auto_mode::cache>;
 
 
 // info argument objects
@@ -47,17 +54,17 @@ struct compute_pipeline_state;
 struct fence;
 struct query_range;
 struct swapchain;
-using auto_shader_binary = auto_destroyer<shader_binary, false>;
-using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, false>;
-using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
-using auto_fence = auto_destroyer<fence, false>;
-using auto_query_range = auto_destroyer<query_range, false>;
-using auto_swapchain = auto_destroyer<swapchain, false>;
+using auto_shader_binary = auto_destroyer<shader_binary, auto_mode::destroy>;
+using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, auto_mode::guard>;
+using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, auto_mode::guard>;
+using auto_fence = auto_destroyer<fence, auto_mode::guard>;
+using auto_query_range = auto_destroyer<query_range, auto_mode::guard>;
+using auto_swapchain = auto_destroyer<swapchain, auto_mode::guard>;
 
 // shader arguments
 struct argument;
 struct prebuilt_argument;
-using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, false>;
+using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, auto_mode::guard>;
 
 // RAII frame chain
 namespace raii

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -93,21 +93,21 @@ struct swapchain
 // auto_ and cached_ aliases
 
 // move-only, self-destructing versions
-using auto_buffer = auto_destroyer<buffer, false>;
-using auto_render_target = auto_destroyer<render_target, false>;
-using auto_texture = auto_destroyer<texture, false>;
+using auto_buffer = auto_destroyer<buffer, auto_mode::guard>;
+using auto_render_target = auto_destroyer<render_target, auto_mode::guard>;
+using auto_texture = auto_destroyer<texture, auto_mode::guard>;
 
-using auto_shader_binary = auto_destroyer<shader_binary, false>;
-using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, false>;
-using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, false>;
-using auto_fence = auto_destroyer<fence, false>;
-using auto_query_range = auto_destroyer<query_range, false>;
-using auto_swapchain = auto_destroyer<swapchain, false>;
+using auto_shader_binary = auto_destroyer<shader_binary, auto_mode::destroy>; // this is a CPU-only type, allow auto destruction
+using auto_graphics_pipeline_state = auto_destroyer<graphics_pipeline_state, auto_mode::guard>;
+using auto_compute_pipeline_state = auto_destroyer<compute_pipeline_state, auto_mode::guard>;
+using auto_fence = auto_destroyer<fence, auto_mode::guard>;
+using auto_query_range = auto_destroyer<query_range, auto_mode::guard>;
+using auto_swapchain = auto_destroyer<swapchain, auto_mode::guard>;
 
 // move-only, self-cachefreeing versions
-using cached_buffer = auto_destroyer<buffer, true>;
-using cached_render_target = auto_destroyer<render_target, true>;
-using cached_texture = auto_destroyer<texture, true>;
+using cached_buffer = auto_destroyer<buffer, auto_mode::cache>;
+using cached_render_target = auto_destroyer<render_target, auto_mode::cache>;
+using cached_texture = auto_destroyer<texture, auto_mode::cache>;
 
 
 };


### PR DESCRIPTION
#### Lifetime Rules
- change the semantics of `auto_` types
    - instead of silently self-destructing, now asserts false when dropped without `.disown()` and explicit free
        - exceptions: cached types (unchanged behavior), and shader binaries (which are CPU only)
    - add `Context::flush_and_shutdown()`, after which no frame submits are accepted and auto_ drops no longer assert
        - called once at global application shutdown to avoid tedium for "static" auto_ resources
    - `.unlock()` renamed to `.disown()` (non-breaking with redirect)
- `CompiledFrame` no longer auto-discards in dtor but asserts instead (that it must be either submitted or discarded)

#### Additions
- Add `free_range` methods to efficiently free multiple resources at once 
- Add `Frame::auto_upload_texture_data` which calls `upload_texture_data` with an automatically created (and destroyed), matching upload buffer
- Add `set_viewport_offset` to framebuffer builder

#### Minor
- Only flush on buffer writes, only invalidate on buffer reads
- Assert that vertex buffers specify stride to mitigate silent d3d12 issues
