### PR TITLE
Instancing, Fixes, PSO Deferred Free, DLL Support

### DIFF
--- a/src/phantasm-renderer/CompiledFrame.hh
+++ b/src/phantasm-renderer/CompiledFrame.hh
@@ -4,6 +4,7 @@
 
 #include <phantasm-hardware-interface/handles.hh>
 
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/common/state_info.hh>
 
 namespace pr
@@ -12,7 +13,7 @@ class Context;
 
 /// A compiled command list ready for submission, as received from Context::compile(frame)
 /// move-only, must be submitted or discarded via the Context before destruction
-class CompiledFrame
+class PR_API CompiledFrame
 {
 public:
     CompiledFrame() = default;

--- a/src/phantasm-renderer/ComputePass.cc
+++ b/src/phantasm-renderer/ComputePass.cc
@@ -4,13 +4,30 @@
 
 #include "Frame.hh"
 
-void pr::raii::ComputePass::dispatch(unsigned x, unsigned y, unsigned z)
+void pr::raii::ComputePass::dispatch(uint32_t x, uint32_t y, uint32_t z)
 {
+    CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at dispatch submission");
+
     mCmd.dispatch_x = x;
     mCmd.dispatch_y = y;
     mCmd.dispatch_z = z;
 
     mParent->passOnDispatch(mCmd);
+}
+
+void pr::raii::ComputePass::dispatch_indirect(buffer const& argument_buffer, uint32_t num_arguments, uint32_t offset_bytes)
+{
+    CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at dispatch submission");
+
+    phi::cmd::dispatch_indirect dcmd;
+    std::memcpy(dcmd.root_constants, mCmd.root_constants, sizeof(dcmd.root_constants));
+    std::memcpy(dcmd.shader_arguments.data(), mCmd.shader_arguments.data(), sizeof(dcmd.shader_arguments));
+    dcmd.pipeline_state = mCmd.pipeline_state;
+    dcmd.argument_buffer_addr.buffer = argument_buffer.res.handle;
+    dcmd.argument_buffer_addr.offset_bytes = offset_bytes;
+    dcmd.num_arguments = num_arguments;
+
+    mParent->write_raw_cmd(dcmd);
 }
 
 void pr::raii::ComputePass::add_cached_argument(const pr::argument& arg, phi::handle::resource constant_buffer, uint32_t constant_buffer_offset)

--- a/src/phantasm-renderer/ComputePass.cc
+++ b/src/phantasm-renderer/ComputePass.cc
@@ -13,15 +13,8 @@ void pr::raii::ComputePass::dispatch(unsigned x, unsigned y, unsigned z)
     mParent->passOnDispatch(mCmd);
 }
 
-
-void pr::raii::ComputePass::add_argument(const pr::argument& arg)
+void pr::raii::ComputePass::add_cached_argument(const pr::argument& arg, phi::handle::resource constant_buffer, uint32_t constant_buffer_offset)
 {
     ++mArgNum;
-    mCmd.add_shader_arg(phi::handle::null_resource, 0, mParent->passAcquireComputeShaderView(arg));
-}
-
-void pr::raii::ComputePass::add_argument(const pr::argument& arg, const pr::buffer& constant_buffer, uint32_t constant_buffer_offset)
-{
-    ++mArgNum;
-    mCmd.add_shader_arg(constant_buffer.res.handle, constant_buffer_offset, mParent->passAcquireComputeShaderView(arg));
+    mCmd.add_shader_arg(constant_buffer, constant_buffer_offset, mParent->passAcquireComputeShaderView(arg));
 }

--- a/src/phantasm-renderer/ComputePass.hh
+++ b/src/phantasm-renderer/ComputePass.hh
@@ -3,6 +3,7 @@
 #include <phantasm-hardware-interface/commands.hh>
 
 #include <phantasm-renderer/argument.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/fwd.hh>
 #include <phantasm-renderer/resource_types.hh>
 
@@ -10,7 +11,7 @@ namespace pr::raii
 {
 class Frame;
 
-class ComputePass
+class PR_API ComputePass
 {
 public:
     template <class... Args>

--- a/src/phantasm-renderer/ComputePass.hh
+++ b/src/phantasm-renderer/ComputePass.hh
@@ -60,7 +60,9 @@ public:
         return p;
     }
 
-    void dispatch(unsigned x, unsigned y = 1, unsigned z = 1);
+    void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1);
+
+    void dispatch_indirect(buffer const& argument_buffer, uint32_t num_arguments = 1, uint32_t offset_bytes = 0);
 
     void set_constant_buffer(buffer const& constant_buffer, unsigned offset = 0);
     void set_constant_buffer(phi::handle::resource raw_cbv, unsigned offset = 0);

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -232,9 +232,15 @@ void Context::free_deferred(buffer const& buf) { free_deferred(buf.res.handle); 
 void Context::free_deferred(texture const& tex) { free_deferred(tex.res.handle); }
 void Context::free_deferred(render_target const& rt) { free_deferred(rt.res.handle); }
 void Context::free_deferred(raw_resource const& res) { free_deferred(res.handle); }
+void Context::free_deferred(graphics_pipeline_state const& gpso) { free_deferred(gpso._handle); }
+void Context::free_deferred(compute_pipeline_state const& cpso) { free_deferred(cpso._handle); }
+
 void Context::free_deferred(phi::handle::resource res) { mDeferredQueue.free(*this, res); }
+void Context::free_deferred(phi::handle::shader_view sv) { mDeferredQueue.free(*this, sv); }
+void Context::free_deferred(phi::handle::pipeline_state pso) { mDeferredQueue.free(*this, pso); }
 
 void Context::free_range_deferred(cc::span<const phi::handle::resource> res_range) { mDeferredQueue.free_range(*this, res_range); }
+void Context::free_range_deferred(cc::span<const phi::handle::shader_view> sv_range) { mDeferredQueue.free_range(*this, sv_range); }
 
 void Context::free_to_cache_untyped(const raw_resource& resource, const generic_resource_info& info)
 {

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -448,7 +448,9 @@ void Context::present(swapchain const& sc)
 #ifdef CC_ENABLE_ASSERTIONS
     CC_ASSERT(mSafetyState.did_acquire_before_present && "Context::present without prior acquire_backbuffer");
 #endif
+
     mBackend->present(sc.handle);
+
 #ifdef CC_ENABLE_ASSERTIONS
     mSafetyState.did_acquire_before_present = false;
 #endif

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -138,7 +138,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     {
         auto lg = std::lock_guard(mMutexShaderCompilation); // unsynced, mutex: compilation
-        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output, build_debug, nullptr, nullptr, nullptr, scratch_alloc);
+        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output, build_debug, nullptr, nullptr, {}, scratch_alloc);
     }
 
     if (bin.data == nullptr)

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -45,37 +45,37 @@ dxcw::target stage_to_dxcw_target(phi::shader_stage stage)
 
 raii::Frame Context::make_frame(size_t initial_size, cc::allocator* alloc) { return pr::raii::Frame{this, initial_size, alloc}; }
 
-auto_texture Context::make_texture(int width, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture(int32_t width, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, {width, 1}, num_mips, phi::texture_dimension::t1d, 1u, allow_uav);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture(tg::isize2 size, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, size, num_mips, phi::texture_dimension::t2d, 1u, allow_uav);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture(tg::isize3 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture(tg::isize3 size, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, {size.width, size.height}, num_mips, phi::texture_dimension::t3d, size.depth, allow_uav);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_cube(tg::isize2 size, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture_cube(tg::isize2 size, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, size, num_mips, phi::texture_dimension::t2d, 6u, allow_uav);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_array(int width, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture_array(int32_t width, uint32_t num_elems, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, {width, 1}, num_mips, phi::texture_dimension::t1d, num_elems, allow_uav);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_texture_array(tg::isize2 size, unsigned num_elems, phi::format format, unsigned num_mips, bool allow_uav, char const* debug_name)
+auto_texture Context::make_texture_array(tg::isize2 size, uint32_t num_elems, phi::format format, uint32_t num_mips, bool allow_uav, char const* debug_name)
 {
     auto const info = texture_info::create_tex(format, size, num_mips, phi::texture_dimension::t2d, num_elems, allow_uav);
     return {createTexture(info, debug_name), this};
@@ -83,31 +83,31 @@ auto_texture Context::make_texture_array(tg::isize2 size, unsigned num_elems, ph
 
 auto_texture Context::make_texture(const texture_info& info, char const* debug_name) { return {createTexture(info, debug_name), this}; }
 
-auto_texture Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, char const* debug_name)
+auto_texture Context::make_target(tg::isize2 size, phi::format format, uint32_t num_samples, uint32_t array_size, char const* debug_name)
 {
     auto const info = texture_info::create_rt(format, size, num_samples, array_size);
     return {createTexture(info, debug_name), this};
 }
 
-auto_texture Context::make_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear, char const* debug_name)
+auto_texture Context::make_target(tg::isize2 size, phi::format format, uint32_t num_samples, uint32_t array_size, phi::rt_clear_value optimized_clear, char const* debug_name)
 {
     auto const info = texture_info::create_rt(format, size, num_samples, array_size, optimized_clear);
     return {createTexture(info, debug_name), this};
 }
 
-auto_buffer Context::make_buffer(unsigned size, unsigned stride, bool allow_uav, char const* debug_name)
+auto_buffer Context::make_buffer(uint32_t size, uint32_t stride, bool allow_uav, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, allow_uav, phi::resource_heap::gpu};
     return {createBuffer(info, debug_name), this};
 }
 
-auto_buffer Context::make_upload_buffer(unsigned size, unsigned stride, char const* debug_name)
+auto_buffer Context::make_upload_buffer(uint32_t size, uint32_t stride, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::upload};
     return {createBuffer(info, debug_name), this};
 }
 
-auto_buffer Context::make_readback_buffer(unsigned size, unsigned stride, char const* debug_name)
+auto_buffer Context::make_readback_buffer(uint32_t size, uint32_t stride, char const* debug_name)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::readback};
     return {createBuffer(info, debug_name), this};
@@ -196,13 +196,13 @@ auto_compute_pipeline_state Context::make_pipeline_state(const compute_pass_info
 
 auto_fence Context::make_fence() { return auto_fence{{mBackend->createFence()}, this}; }
 
-auto_query_range Context::make_query_range(phi::query_type type, unsigned num_queries)
+auto_query_range Context::make_query_range(phi::query_type type, uint32_t num_queries)
 {
     auto const handle = mBackend->createQueryRange(type, num_queries);
     return auto_query_range{{handle, type, num_queries}, this};
 }
 
-auto_swapchain Context::make_swapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, pr::present_mode mode, unsigned num_backbuffers)
+auto_swapchain Context::make_swapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, pr::present_mode mode, uint32_t num_backbuffers)
 {
     return {{mBackend->createSwapchain(window_handle, initial_size, mode, num_backbuffers)}, this};
 }
@@ -258,8 +258,8 @@ void Context::write_to_buffer_raw(const buffer& buffer, cc::span<std::byte const
     CC_ASSERT(buffer.info.heap == phi::resource_heap::upload && "Attempted to write to non-upload buffer");
     CC_ASSERT(buffer.info.size_bytes >= data.size_bytes() + offset_in_buffer && "Buffer write out of bounds");
 
-    int const map_begin = int(offset_in_buffer);
-    int const map_end = int(offset_in_buffer + data.size_bytes());
+    int32_t const map_begin = int(offset_in_buffer);
+    int32_t const map_end = int(offset_in_buffer + data.size_bytes());
 
     std::byte* const map = map_buffer(buffer, 0, 0); // invalidate nothing
     std::memcpy(map + offset_in_buffer, data.data(), data.size_bytes());
@@ -271,8 +271,8 @@ void Context::read_from_buffer_raw(const buffer& buffer, cc::span<std::byte> out
     CC_ASSERT(buffer.info.heap == phi::resource_heap::readback && "Attempted to read from non-readback buffer");
     CC_ASSERT(buffer.info.size_bytes >= out_data.size_bytes() + offset_in_buffer && "Buffer read out of bounds");
 
-    int const map_begin = int(offset_in_buffer);
-    int const map_end = int(offset_in_buffer + out_data.size_bytes());
+    int32_t const map_begin = int(offset_in_buffer);
+    int32_t const map_end = int(offset_in_buffer + out_data.size_bytes());
 
     std::byte const* const map = map_buffer(buffer, map_begin, map_end); // invalidate the whole range
     std::memcpy(out_data.data(), map + offset_in_buffer, out_data.size_bytes());
@@ -285,38 +285,41 @@ void Context::wait_fence_cpu(const fence& fence, uint64_t wait_value) { mBackend
 
 uint64_t Context::get_fence_value(const fence& fence) { return mBackend->getFenceValue(fence.handle); }
 
-std::byte* Context::map_buffer(const buffer& buffer, int invalidate_begin, int invalidate_end)
+std::byte* Context::map_buffer(const buffer& buffer, int32_t invalidate_begin, int32_t invalidate_end)
 {
     return mBackend->mapBuffer(buffer.res.handle, invalidate_begin, invalidate_end);
 }
 
-void Context::unmap_buffer(const buffer& buffer, int flush_begin, int flush_end) { mBackend->unmapBuffer(buffer.res.handle, flush_begin, flush_end); }
+void Context::unmap_buffer(const buffer& buffer, int32_t flush_begin, int32_t flush_end)
+{
+    mBackend->unmapBuffer(buffer.res.handle, flush_begin, flush_end);
+}
 
-cached_texture Context::get_target(tg::isize2 size, phi::format format, unsigned num_samples, unsigned array_size)
+cached_texture Context::get_target(tg::isize2 size, phi::format format, uint32_t num_samples, uint32_t array_size)
 {
     auto const info = texture_info::create_rt(format, size, num_samples, array_size);
     return {acquireTexture(info), this};
 }
 
-cached_texture Context::get_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear)
+cached_texture Context::get_target(tg::isize2 size, format format, uint32_t num_samples, uint32_t array_size, phi::rt_clear_value optimized_clear)
 {
     auto const info = texture_info::create_rt(format, size, num_samples, array_size, optimized_clear);
     return {acquireTexture(info), this};
 }
 
-cached_buffer Context::get_buffer(unsigned size, unsigned stride, bool allow_uav)
+cached_buffer Context::get_buffer(uint32_t size, uint32_t stride, bool allow_uav)
 {
     auto const info = buffer_info{size, stride, allow_uav, phi::resource_heap::gpu};
     return {acquireBuffer(info), this};
 }
 
-cached_buffer Context::get_upload_buffer(unsigned size, unsigned stride)
+cached_buffer Context::get_upload_buffer(uint32_t size, uint32_t stride)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::upload};
     return {acquireBuffer(info), this};
 }
 
-cached_buffer Context::get_readback_buffer(unsigned size, unsigned stride)
+cached_buffer Context::get_readback_buffer(uint32_t size, uint32_t stride)
 {
     auto const info = buffer_info{size, stride, false, phi::resource_heap::readback};
     return {acquireBuffer(info), this};
@@ -459,14 +462,14 @@ tg::isize2 Context::get_backbuffer_size(swapchain const& sc) const { return mBac
 
 phi::format Context::get_backbuffer_format(swapchain const& sc) const { return mBackend->getBackbufferFormat(sc.handle); }
 
-unsigned Context::get_num_backbuffers(swapchain const& sc) const { return mBackend->getNumBackbuffers(sc.handle); }
+uint32_t Context::get_num_backbuffers(swapchain const& sc) const { return mBackend->getNumBackbuffers(sc.handle); }
 
-unsigned Context::calculate_texture_upload_size(tg::isize3 size, phi::format fmt, unsigned num_mips) const
+uint32_t Context::calculate_texture_upload_size(tg::isize3 size, phi::format fmt, uint32_t num_mips) const
 {
     return phi::util::get_texture_size_bytes(size, fmt, num_mips, mBackendType == pr::backend::d3d12);
 }
 
-unsigned Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const
+uint32_t Context::calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const
 {
     return phi::util::get_texture_pixel_byte_offset(size, fmt, pixel, mBackendType == pr::backend::d3d12);
 }
@@ -487,7 +490,7 @@ texture Context::acquire_backbuffer(swapchain const& sc)
     return {{backbuffer, backbuffer.is_valid() ? acquireGuid() : 0}, texture_info::create_rt(mBackend->getBackbufferFormat(sc.handle), size)};
 }
 
-unsigned Context::clear_resource_caches()
+uint32_t Context::clear_resource_caches()
 {
     cc::vector<phi::handle::resource> freeable;
     freeable.reserve(100);
@@ -498,10 +501,10 @@ unsigned Context::clear_resource_caches()
     mCacheBuffers.cull_all(gpu_epoch, [&](phi::handle::resource rt) { freeable.push_back(rt); });
 
     mBackend->freeRange(freeable);
-    return unsigned(freeable.size());
+    return uint32_t(freeable.size());
 }
 
-unsigned Context::clear_shader_view_cache()
+uint32_t Context::clear_shader_view_cache()
 {
     cc::vector<phi::handle::shader_view> freeable;
     freeable.reserve(100);
@@ -512,12 +515,12 @@ unsigned Context::clear_shader_view_cache()
     mCacheComputeSVs.cull_all(gpu_epoch, [&](phi::handle::shader_view sv) { freeable.push_back(sv); });
 
     mBackend->freeRange(freeable);
-    return unsigned(freeable.size());
+    return uint32_t(freeable.size());
 }
 
-unsigned Context::clear_pipeline_state_cache()
+uint32_t Context::clear_pipeline_state_cache()
 {
-    unsigned num_frees = 0;
+    uint32_t num_frees = 0;
     auto const gpu_epoch = mGpuEpochTracker._cached_epoch_gpu;
 
     mCacheGraphicsPSOs.cull_all(gpu_epoch, [&](phi::handle::pipeline_state pso) {
@@ -532,7 +535,7 @@ unsigned Context::clear_pipeline_state_cache()
     return num_frees;
 }
 
-unsigned Context::clear_pending_deferred_frees() { return mDeferredQueue.free_all_pending(*this); }
+uint32_t Context::clear_pending_deferred_frees() { return mDeferredQueue.free_all_pending(*this); }
 
 void Context::initialize(backend type, cc::allocator* alloc)
 {
@@ -622,7 +625,7 @@ buffer Context::createBuffer(const buffer_info& info, char const* dbg_name)
 {
     CC_ASSERT((info.allow_uav ? info.heap == phi::resource_heap::gpu : true) && "mapped buffers cannot be created with UAV support");
 
-    phi::handle::resource handle = mBackend->createBufferFromInfo(info, dbg_name);
+    phi::handle::resource handle = mBackend->createBuffer(info, dbg_name);
     return {{handle, acquireGuid()}, info};
 }
 
@@ -750,22 +753,22 @@ void Context::free_compute_pso(cc::hash_t hash) { mCacheComputePSOs.free(hash, m
 void Context::free_graphics_sv(cc::hash_t hash) { mCacheGraphicsSVs.free(hash, mGpuEpochTracker.get_current_epoch_cpu()); }
 void Context::free_compute_sv(cc::hash_t hash) { mCacheComputeSVs.free(hash, mGpuEpochTracker.get_current_epoch_cpu()); }
 
-auto_buffer pr::Context::make_upload_buffer_for_texture(const texture& tex, unsigned num_mips, const char* debug_name)
+auto_buffer pr::Context::make_upload_buffer_for_texture(const texture& tex, uint32_t num_mips, const char* debug_name)
 {
     return make_upload_buffer(calculate_texture_upload_size(tex, num_mips), 0, debug_name);
 }
 
-unsigned pr::Context::calculate_texture_upload_size(const texture& texture, unsigned num_mips) const
+uint32_t pr::Context::calculate_texture_upload_size(const texture& texture, uint32_t num_mips) const
 {
     return calculate_texture_upload_size({texture.info.width, texture.info.height, int(texture.info.depth_or_array_size)}, texture.info.fmt, num_mips);
 }
 
-unsigned pr::Context::calculate_texture_upload_size(int width, format fmt, unsigned num_mips) const
+uint32_t pr::Context::calculate_texture_upload_size(int32_t width, format fmt, uint32_t num_mips) const
 {
     return calculate_texture_upload_size({width, 1, 1}, fmt, num_mips);
 }
 
-unsigned pr::Context::calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips) const
+uint32_t pr::Context::calculate_texture_upload_size(tg::isize2 size, format fmt, uint32_t num_mips) const
 {
     return calculate_texture_upload_size({size.width, size.height, 1}, fmt, num_mips);
 }

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -183,9 +183,13 @@ auto_prebuilt_argument Context::make_compute_argument(cc::span<const phi::resour
 auto_graphics_pipeline_state Context::make_pipeline_state(const graphics_pass_info& gp_wrap, const framebuffer_info& fb)
 {
     auto const& gp = gp_wrap._storage.get();
-    return auto_graphics_pipeline_state{{{mBackend->createPipelineState({gp.vertex_attributes, gp.vertex_size_bytes}, fb._storage.get(),
-                                                                        gp.arg_shapes, gp.has_root_consts, gp_wrap._shaders, gp.graphics_config)}},
-                                        this};
+
+    phi::arg::vertex_format vert_format;
+    vert_format.attributes = gp.vertex_attributes;
+    vert_format.vertex_sizes_bytes[0] = gp.vertex_size_bytes;
+
+    return auto_graphics_pipeline_state{
+        {{mBackend->createPipelineState(vert_format, fb._storage.get(), gp.arg_shapes, gp.has_root_consts, gp_wrap._shaders, gp.graphics_config)}}, this};
 }
 
 auto_compute_pipeline_state Context::make_pipeline_state(const compute_pass_info& cp_wrap)

--- a/src/phantasm-renderer/Context.cc
+++ b/src/phantasm-renderer/Context.cc
@@ -135,7 +135,7 @@ auto_shader_binary Context::make_shader(cc::span<cc::byte const> data, phi::shad
     return {res, this};
 }
 
-auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view entrypoint, phi::shader_stage stage)
+auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view entrypoint, phi::shader_stage stage, bool build_debug, cc::allocator* scratch_alloc)
 {
     dxcw::binary bin;
 
@@ -144,7 +144,7 @@ auto_shader_binary Context::make_shader(cc::string_view code, cc::string_view en
 
     {
         auto lg = std::lock_guard(mMutexShaderCompilation); // unsynced, mutex: compilation
-        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output);
+        bin = mShaderCompiler.compile_shader(code.data(), entrypoint.data(), sc_target, sc_output, build_debug, nullptr, nullptr, nullptr, scratch_alloc);
     }
 
     if (bin.data == nullptr)

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -122,7 +122,9 @@ public:
     [[nodiscard]] auto_shader_binary make_shader(cc::span<cc::byte const> data, pr::shader stage);
 
     /// create a shader by compiling it live from text
-    [[nodiscard]] auto_shader_binary make_shader(cc::string_view code, cc::string_view entrypoint, pr::shader stage);
+    /// build_debug: compile without optimizations and embed debug symbols/PDB info (/Od /Zi /Qembed_debug) - required for shader debugging in Rdoc, PIX etc
+    [[nodiscard]] auto_shader_binary make_shader(
+        cc::string_view code, cc::string_view entrypoint, pr::shader stage, bool build_debug = false, cc::allocator* scratch_alloc = cc::system_allocator);
 
     //
     // prebuilt arguments (shader views)
@@ -631,7 +633,7 @@ private:
     pr::backend mBackendType;
 
     // constant info
-    uint64_t mGPUTimestampFrequency;
+    uint64_t mGPUTimestampFrequency = 0;
 
     // components
     dxcw::compiler mShaderCompiler;

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -20,6 +20,7 @@
 #include <phantasm-renderer/detail/deferred_destruction_queue.hh>
 
 #include <phantasm-renderer/argument.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
 
@@ -30,7 +31,7 @@ namespace pr
  *
  *
  */
-class Context
+class PR_API Context
 {
 public:
     //

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -343,7 +343,6 @@ public:
     [[nodiscard]] bool clear_backbuffer_resize(swapchain const& sc);
 
     /// acquires the next backbuffer in line
-    /// this should occur as late as possible into the frame
     [[nodiscard]] render_target acquire_backbuffer(swapchain const& sc);
 
     /// returns the size of the swapchain's backbuffers

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -45,23 +45,23 @@ public:
     // textures
 
     /// create a 1D texture
-    [[nodiscard]] auto_texture make_texture(int width, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_texture(int32_t width, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a 2D texture
-    [[nodiscard]] auto_texture make_texture(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_texture(tg::isize2 size, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a 3D texture
-    [[nodiscard]] auto_texture make_texture(tg::isize3 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_texture(tg::isize3 size, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a texture cube
-    [[nodiscard]] auto_texture make_texture_cube(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_texture_cube(tg::isize2 size, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a 1D texture array
-    [[nodiscard]] auto_texture make_texture_array(int width, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_texture_array(int32_t width, uint32_t num_elems, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a 2D texture array
     [[nodiscard]] auto_texture make_texture_array(
-        tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+        tg::isize2 size, uint32_t num_elems, format format, uint32_t num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a texture from an info struct
     [[nodiscard]] auto_texture make_texture(texture_info const& info, char const* debug_name = nullptr);
@@ -76,26 +76,26 @@ public:
     // render targets
 
     /// create a render target
-    [[nodiscard]] auto_texture make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1, char const* debug_name = nullptr);
+    [[nodiscard]] auto_texture make_target(tg::isize2 size, format format, uint32_t num_samples = 1, uint32_t array_size = 1, char const* debug_name = nullptr);
 
     /// create a render target with an optimized clear value
     [[nodiscard]] auto_texture make_target(
-        tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear, char const* debug_name = nullptr);
+        tg::isize2 size, format format, uint32_t num_samples, uint32_t array_size, phi::rt_clear_value optimized_clear, char const* debug_name = nullptr);
 
     //
     // buffers
 
     /// create a buffer
-    [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false, char const* debug_name = nullptr);
+    [[nodiscard]] auto_buffer make_buffer(uint32_t size, uint32_t stride = 0, bool allow_uav = false, char const* debug_name = nullptr);
 
     /// create a mapped upload buffer which can be directly written to from CPU
-    [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
+    [[nodiscard]] auto_buffer make_upload_buffer(uint32_t size, uint32_t stride = 0, char const* debug_name = nullptr);
 
     /// create a mapped upload buffer, with a size based on accomodating a given texture's contents
-    [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1, char const* debug_name = nullptr);
+    [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, uint32_t num_mips = 1, char const* debug_name = nullptr);
 
     /// create a mapped readback buffer which can be directly read from CPU
-    [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
+    [[nodiscard]] auto_buffer make_readback_buffer(uint32_t size, uint32_t stride = 0, char const* debug_name = nullptr);
 
     /// create a buffer from an info struct
     [[nodiscard]] auto_buffer make_buffer(buffer_info const& info, char const* debug_name = nullptr);
@@ -152,22 +152,22 @@ public:
     // query ranges
 
     /// create a contiguous range of queries
-    [[nodiscard]] auto_query_range make_query_range(pr::query_type type, unsigned num_queries);
+    [[nodiscard]] auto_query_range make_query_range(pr::query_type type, uint32_t num_queries);
 
     //
     // resource cache lookup
     //
 
     /// create or retrieve a render target from the cache
-    [[nodiscard]] cached_texture get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+    [[nodiscard]] cached_texture get_target(tg::isize2 size, format format, uint32_t num_samples = 1, uint32_t array_size = 1);
 
     /// create or retrieve a render target with an optimized clear value from the cache
-    [[nodiscard]] cached_texture get_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
+    [[nodiscard]] cached_texture get_target(tg::isize2 size, format format, uint32_t num_samples, uint32_t array_size, phi::rt_clear_value optimized_clear);
 
     /// create or retrieve a buffer from the cache
-    [[nodiscard]] cached_buffer get_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false);
-    [[nodiscard]] cached_buffer get_upload_buffer(unsigned size, unsigned stride = 0);
-    [[nodiscard]] cached_buffer get_readback_buffer(unsigned size, unsigned stride = 0);
+    [[nodiscard]] cached_buffer get_buffer(uint32_t size, uint32_t stride = 0, bool allow_uav = false);
+    [[nodiscard]] cached_buffer get_upload_buffer(uint32_t size, uint32_t stride = 0);
+    [[nodiscard]] cached_buffer get_readback_buffer(uint32_t size, uint32_t stride = 0);
     [[nodiscard]] cached_buffer get_buffer(buffer_info const& info);
 
     /// create or retrieve a texture from the cache
@@ -274,10 +274,10 @@ public:
     /// a buffer can be mapped multiple times at once
     /// invalidate_begin and -end specify the range of CPU-side read data in bytes, end == -1 being the entire width
     /// NOTE: begin > 0 does not add an offset to the returned pointer
-    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int invalidate_begin = 0, int invalidate_end = -1);
+    [[nodiscard]] std::byte* map_buffer(buffer const& buffer, int32_t invalidate_begin = 0, int32_t invalidate_end = -1);
 
     /// map a buffer and return a span of the mapped memory (instead of just a pointer)
-    [[nodiscard]] cc::span<std::byte> map_buffer_as_span(buffer const& buffer, int invalidate_begin = 0, int invalidate_end = -1)
+    [[nodiscard]] cc::span<std::byte> map_buffer_as_span(buffer const& buffer, int32_t invalidate_begin = 0, int32_t invalidate_end = -1)
     {
         return {map_buffer(buffer, invalidate_begin, invalidate_end), buffer.info.size_bytes};
     }
@@ -286,7 +286,7 @@ public:
     /// a buffer can be destroyed while mapped
     /// on non-desktop it might be required to unmap upload buffers for the writes to become visible
     /// begin and end specify the range of CPU-side modified data in bytes, end == -1 being the entire width
-    void unmap_buffer(buffer const& buffer, int flush_begin = 0, int flush_end = -1);
+    void unmap_buffer(buffer const& buffer, int32_t flush_begin = 0, int32_t flush_end = -1);
 
     /// map an upload buffer, memcpy the provided data into it, and unmap it
     void write_to_buffer_raw(buffer const& buffer, cc::span<std::byte const> data, size_t offset_in_buffer = 0);
@@ -357,7 +357,7 @@ public:
     [[nodiscard]] auto_swapchain make_swapchain(phi::window_handle const& window_handle,
                                                 tg::isize2 initial_size,
                                                 pr::present_mode mode = pr::present_mode::synced,
-                                                unsigned num_backbuffers = 3);
+                                                uint32_t num_backbuffers = 3);
 
     /// destroy a swapchain
     void free(swapchain const& sc);
@@ -385,7 +385,7 @@ public:
     format get_backbuffer_format(swapchain const& sc) const;
 
     /// returns the amount of backbuffers a swapchain contains
-    unsigned get_num_backbuffers(swapchain const& sc) const;
+    uint32_t get_num_backbuffers(swapchain const& sc) const;
 
     //
     // GPU synchronization
@@ -408,20 +408,20 @@ public:
 
     /// frees all resources (textures, rendertargets, buffers) from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    unsigned clear_resource_caches();
+    uint32_t clear_resource_caches();
 
     /// frees all shader_views from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    unsigned clear_shader_view_cache();
+    uint32_t clear_shader_view_cache();
 
     /// frees all pipeline_states from pr caches that are not acquired or in flight
     /// returns amount of freed elements
-    unsigned clear_pipeline_state_cache();
+    uint32_t clear_pipeline_state_cache();
 
     /// runs all deferred free operations that are no longer in flight
     /// this also happens automatically on any call to free_deferred
     /// returns amount of freed elements
-    unsigned clear_pending_deferred_frees();
+    uint32_t clear_pending_deferred_frees();
 
     //
     // phi interop
@@ -460,14 +460,14 @@ public:
 
     /// returns the amount of bytes needed to store the contents of a texture (in a GPU buffer)
     /// ex. use case: allocating upload buffers of the right size to upload textures
-    unsigned calculate_texture_upload_size(tg::isize3 size, format fmt, unsigned num_mips = 1) const;
-    unsigned calculate_texture_upload_size(tg::isize2 size, format fmt, unsigned num_mips = 1) const;
-    unsigned calculate_texture_upload_size(int width, format fmt, unsigned num_mips = 1) const;
-    unsigned calculate_texture_upload_size(texture const& texture, unsigned num_mips = 1) const;
+    uint32_t calculate_texture_upload_size(tg::isize3 size, format fmt, uint32_t num_mips = 1) const;
+    uint32_t calculate_texture_upload_size(tg::isize2 size, format fmt, uint32_t num_mips = 1) const;
+    uint32_t calculate_texture_upload_size(int32_t width, format fmt, uint32_t num_mips = 1) const;
+    uint32_t calculate_texture_upload_size(texture const& texture, uint32_t num_mips = 1) const;
 
     /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
     /// ex. use case: copying a render target to a readback buffer, then reading the pixel at this offset
-    unsigned calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const;
+    uint32_t calculate_texture_pixel_offset(tg::isize2 size, format fmt, tg::ivec2 pixel) const;
 
     bool is_shutting_down() const { return mIsShuttingDown.load(std::memory_order_relaxed); }
 

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -207,10 +207,17 @@ public:
     void free_deferred(render_target const& rt);
     /// free a resource once no longer in flight
     void free_deferred(raw_resource const& res);
+
+    /// free a PSO once no longer in flight
+    void free_deferred(graphics_pipeline_state const& gpso);
+    void free_deferred(compute_pipeline_state const& cpso);
+
     /// free raw PHI resources once no longer in flight
     void free_deferred(phi::handle::resource res);
     void free_deferred(phi::handle::shader_view sv);
+    void free_deferred(phi::handle::pipeline_state pso);
     void free_range_deferred(cc::span<phi::handle::resource const> res_range);
+    void free_range_deferred(cc::span<phi::handle::shader_view const> sv_range);
 
     //
     // cache freeing

--- a/src/phantasm-renderer/Context.hh
+++ b/src/phantasm-renderer/Context.hh
@@ -35,99 +35,142 @@ class PR_API Context
 {
 public:
     //
-    // creation API
+    // resource creation
     //
 
     /// start a frame, allowing command recording
     [[nodiscard]] raii::Frame make_frame(size_t initial_size = 2048, cc::allocator* alloc = cc::system_allocator);
 
+    //
+    // textures
+
     /// create a 1D texture
     [[nodiscard]] auto_texture make_texture(int width, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a 2D texture
     [[nodiscard]] auto_texture make_texture(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a 3D texture
     [[nodiscard]] auto_texture make_texture(tg::isize3 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a texture cube
     [[nodiscard]] auto_texture make_texture_cube(tg::isize2 size, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a 1D texture array
     [[nodiscard]] auto_texture make_texture_array(int width, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a 2D texture array
     [[nodiscard]] auto_texture make_texture_array(
         tg::isize2 size, unsigned num_elems, format format, unsigned num_mips = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a texture from an info struct
     [[nodiscard]] auto_texture make_texture(texture_info const& info, char const* debug_name = nullptr);
+
     /// create a texture from the info of a different texture. NOTE: does not concern contents or state
     [[nodiscard]] auto_texture make_texture_clone(texture const& clone_source, char const* debug_name = nullptr)
     {
         return make_texture(clone_source.info, debug_name);
     }
 
+    //
+    // render targets
+
     /// create a render target
     [[nodiscard]] auto_render_target make_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1, char const* debug_name = nullptr);
+
     /// create a render target with an optimized clear value
     [[nodiscard]] auto_render_target make_target(
         tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear, char const* debug_name = nullptr);
+
     /// create a render target from an info struct
     [[nodiscard]] auto_render_target make_target(render_target_info const& info, char const* debug_name = nullptr);
+
     /// create a render target from the info of a different one. NOTE: does not concern contents or state
     [[nodiscard]] auto_render_target make_target_clone(render_target const& clone_source, char const* debug_name = nullptr)
     {
         return make_target(clone_source.info, debug_name);
     }
 
+    //
+    // buffers
+
     /// create a buffer
     [[nodiscard]] auto_buffer make_buffer(unsigned size, unsigned stride = 0, bool allow_uav = false, char const* debug_name = nullptr);
+
     /// create a mapped upload buffer which can be directly written to from CPU
     [[nodiscard]] auto_buffer make_upload_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
+
     /// create a mapped upload buffer, with a size based on accomodating a given texture's contents
     [[nodiscard]] auto_buffer make_upload_buffer_for_texture(texture const& tex, unsigned num_mips = 1, char const* debug_name = nullptr);
+
     /// create a mapped readback buffer which can be directly read from CPU
     [[nodiscard]] auto_buffer make_readback_buffer(unsigned size, unsigned stride = 0, char const* debug_name = nullptr);
+
     /// create a buffer from an info struct
     [[nodiscard]] auto_buffer make_buffer(buffer_info const& info, char const* debug_name = nullptr);
+
     /// create a buffer from the info of a different buffer. NOTE: does not concern contents or state
     [[nodiscard]] auto_buffer make_buffer_clone(buffer const& clone_source, char const* debug_name = nullptr)
     {
         return make_buffer(clone_source.info, debug_name);
     }
 
+    //
+    // shaders
 
     /// create a shader from binary data (only hashes the data)
     [[nodiscard]] auto_shader_binary make_shader(cc::span<cc::byte const> data, pr::shader stage);
+
     /// create a shader by compiling it live from text
     [[nodiscard]] auto_shader_binary make_shader(cc::string_view code, cc::string_view entrypoint, pr::shader stage);
 
+    //
+    // prebuilt arguments (shader views)
+
     /// create a persisted shader argument for graphics passes
     [[nodiscard]] auto_prebuilt_argument make_graphics_argument(pr::argument const& arg);
+
     /// create a persisted shader argument for graphics passes from raw phi types
     [[nodiscard]] auto_prebuilt_argument make_graphics_argument(cc::span<phi::resource_view const> srvs,
                                                                 cc::span<phi::resource_view const> uavs,
                                                                 cc::span<phi::sampler_config const> samplers);
+
     /// create a persisted shader argument for compute passes
     [[nodiscard]] auto_prebuilt_argument make_compute_argument(pr::argument const& arg);
+
     /// create a persisted shader argument for compute passes from raw phi types
     [[nodiscard]] auto_prebuilt_argument make_compute_argument(cc::span<phi::resource_view const> srvs,
                                                                cc::span<phi::resource_view const> uavs,
                                                                cc::span<phi::sampler_config const> samplers);
+
     /// create a persisted shader argument, builder pattern
     [[nodiscard]] argument_builder build_argument(cc::allocator* temp_alloc = cc::system_allocator) { return {this, temp_alloc}; }
 
+    //
+    // pipeline states
+
     /// create a graphics pipeline state
     [[nodiscard]] auto_graphics_pipeline_state make_pipeline_state(graphics_pass_info const& gp, framebuffer_info const& fb);
+
     /// create a compute pipeline state
     [[nodiscard]] auto_compute_pipeline_state make_pipeline_state(compute_pass_info const& cp);
+
+    //
+    // query ranges
 
     /// create a contiguous range of queries
     [[nodiscard]] auto_query_range make_query_range(pr::query_type type, unsigned num_queries);
 
     //
-    // cache lookup API
+    // resource cache lookup
     //
 
     /// create or retrieve a render target from the cache
     [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples = 1, unsigned array_size = 1);
+
     /// create or retrieve a render target with an optimized clear value from the cache
     [[nodiscard]] cached_render_target get_target(tg::isize2 size, format format, unsigned num_samples, unsigned array_size, phi::rt_clear_value optimized_clear);
+
     /// create or retrieve a render target from an info struct from the cache
     [[nodiscard]] cached_render_target get_target(render_target_info const& info);
 
@@ -140,9 +183,8 @@ public:
     /// create or retrieve a texture from the cache
     [[nodiscard]] cached_texture get_texture(texture_info const& info);
 
-
     //
-    // untyped creation and cache lookup API
+    // untyped resource creation and -cache lookup
     //
 
     /// create a resource of undetermined type, without RAII management (use free_untyped)
@@ -165,8 +207,10 @@ public:
 
     /// free a buffer
     void free(buffer const& buffer) { free_untyped(buffer.res); }
+
     /// free a texture
     void free(texture const& texture) { free_untyped(texture.res); }
+
     /// free a render_target
     void free(render_target const& rt) { free_untyped(rt.res); }
 
@@ -202,10 +246,13 @@ public:
 
     /// free a buffer once no longer in flight
     void free_deferred(buffer const& buf);
+
     /// free a texture once no longer in flight
     void free_deferred(texture const& tex);
+
     /// free a render target once no longer in flight
     void free_deferred(render_target const& rt);
+
     /// free a resource once no longer in flight
     void free_deferred(raw_resource const& res);
 
@@ -228,10 +275,13 @@ public:
 
     /// free a resource of undetermined type by placing it in the cache for reuse
     void free_to_cache_untyped(raw_resource const& resource, generic_resource_info const& info);
+
     /// free a buffer by placing it in the cache for reuse
     void free_to_cache(buffer const& buffer);
+
     /// free a texture by placing it in the cache for reuse
     void free_to_cache(texture const& texture);
+
     /// free a render target by placing it in the cache for reuse
     void free_to_cache(render_target const& rt);
 
@@ -292,6 +342,7 @@ public:
 
     /// signal a fence to a given value from CPU
     void signal_fence_cpu(fence const& fence, uint64_t new_value);
+
     /// block on CPU until a fence reaches a given value
     void wait_fence_cpu(fence const& fence, uint64_t wait_value);
 
@@ -458,6 +509,7 @@ public:
 
     /// attempts to start a capture in a connected tool like Renderdoc, PIX, NSight etc
     bool start_capture();
+
     /// ends a capture previously started with start_capture()
     bool stop_capture();
 
@@ -477,13 +529,16 @@ public:
     //
 
     Context() = default;
+
     /// internally create a backend with default config
     explicit Context(backend type, cc::allocator* alloc = cc::system_allocator) { initialize(type, alloc); }
+
     /// internally create a backend with specified config
     explicit Context(backend type, phi::backend_config const& config, cc::allocator* alloc = cc::system_allocator)
     {
         initialize(type, config, alloc);
     }
+
     /// attach to an existing backend
     explicit Context(phi::Backend* backend, cc::allocator* alloc = cc::system_allocator) { initialize(backend, alloc); }
 

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -476,9 +476,9 @@ raii::Framebuffer raii::Frame::buildFramebuffer(const phi::cmd::begin_render_pas
         {
             transition(bcmd.depth_target.rv.resource, pr::state::depth_write);
         }
-
-        flushPendingTransitions();
     }
+
+    flushPendingTransitions();
 
     mFramebufferActive = true;
     mWriter.add_command(bcmd);

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -102,6 +102,25 @@ void raii::Frame::transition(phi::handle::resource raw_resource, pr::state targe
     mPendingTransitionCommand.add(raw_resource, target, dependency);
 }
 
+void pr::raii::Frame::barrier_uav(cc::span<phi::handle::resource const> resources)
+{
+    phi::cmd::barrier_uav bcmd;
+
+    for (phi::handle::resource const res : resources)
+    {
+        if (bcmd.resources.full())
+        {
+            write_raw_cmd(bcmd);
+            bcmd.resources.clear();
+        }
+
+        bcmd.resources.push_back(res);
+    }
+
+    // empty UAV barrier list is valid as well
+    write_raw_cmd(bcmd);
+}
+
 void raii::Frame::present_after_submit(const render_target& backbuffer, swapchain sc)
 {
     CC_ASSERT(!mPresentAfterSubmitRequest.is_valid() && "only one present_after_submit per pr::raii::Frame allowed");

--- a/src/phantasm-renderer/Frame.cc
+++ b/src/phantasm-renderer/Frame.cc
@@ -369,7 +369,7 @@ void raii::Frame::addRenderTargetToFramebuffer(phi::cmd::begin_render_pass& bcmd
         CC_ASSERT(num_samples == int(rt.info.num_samples) && "make_framebuffer: inconsistent amount of samples in render targets");
     }
 
-    if (phi::is_depth_format(rt.info.format))
+    if (phi::util::is_depth_format(rt.info.format))
     {
         CC_ASSERT(!bcmd.depth_target.rv.resource.is_valid() && "passed multiple depth targets to raii::Frame::make_framebuffer");
         bcmd.set_2d_depth_stencil(rt.res.handle, rt.info.format, phi::rt_clear_type::clear, rt.info.num_samples > 1);

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -9,6 +9,7 @@
 #include <phantasm-hardware-interface/commands.hh>
 
 #include <phantasm-renderer/common/growing_writer.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
 
@@ -19,7 +20,7 @@
 
 namespace pr::raii
 {
-class Frame
+class PR_API Frame
 {
 public:
     //

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -8,8 +8,8 @@
 
 #include <phantasm-hardware-interface/commands.hh>
 
-#include <phantasm-renderer/common/growing_writer.hh>
 #include <phantasm-renderer/common/api.hh>
+#include <phantasm-renderer/common/growing_writer.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -70,6 +70,8 @@ public:
     void transition(render_target const& res, state target, shader_flags dependency = {});
     void transition(phi::handle::resource raw_resource, state target, shader_flags dependency = {});
 
+    void barrier_uav(cc::span<phi::handle::resource const> resources);
+
     /// transition the backbuffer to present state and trigger a Context::present after this frame is submitted
     void present_after_submit(render_target const& backbuffer, swapchain sc);
 

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -78,6 +78,7 @@ public:
 
     /// copy buffer to buffer
     void copy(buffer const& src, buffer const& dest, size_t src_offset = 0, size_t dest_offset = 0, size_t num_bytes = 0);
+
     /// copy buffer to texture
     void copy(buffer const& src, texture const& dest, size_t src_offset = 0, unsigned dest_mip_index = 0, unsigned dest_array_index = 0);
 
@@ -86,10 +87,13 @@ public:
 
     /// copies all array slices at the given MIP level from src to dest
     void copy(texture const& src, texture const& dest, unsigned mip_index = 0);
+
     /// copies MIP level 0, array slice 0 from src to dest
     void copy(texture const& src, render_target const& dest);
+
     /// copies src to MIP level 0, array slice 0 of dest
     void copy(render_target const& src, texture const& dest);
+
     /// copies contents of src to dest
     void copy(render_target const& src, render_target const& dest);
 
@@ -143,14 +147,21 @@ public:
                                       texture const& dest_texture,
                                       unsigned dest_subres_index);
 
+    /// creates a suitable temporary upload buffer and copies data to the destination buffer
+    void auto_upload_buffer_data(cc::span<std::byte const> data, buffer const& dest_buffer);
+
     /// free a buffer once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(buffer const& buf) { free_deferred_after_submit(buf.res.handle); }
+
     /// free a texture once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(texture const& tex) { free_deferred_after_submit(tex.res.handle); }
+
     /// free a render target once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(render_target const& rt) { free_deferred_after_submit(rt.res.handle); }
+
     /// free a resource once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(raw_resource const& res) { free_deferred_after_submit(res.handle); }
+
     /// free raw PHI resources once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(phi::handle::resource res) { mDeferredFreeResources.push_back(res); }
 
@@ -181,8 +192,10 @@ public:
 
 public:
     // redirect intuitive misuses
+
     /// (graphics passes can only be created from framebuffers)
     [[deprecated("did you mean .make_framebuffer(..).make_pass(..)?")]] void make_pass(graphics_pipeline_state const&) = delete;
+
     /// frame must not be discarded while framebuffers/passes are alive
     [[deprecated("pr::raii::Frame must stay alive while passes are used")]] ComputePass make_pass(compute_pipeline_state const&) && = delete;
     [[deprecated("pr::raii::Frame must stay alive while passes are used")]] ComputePass make_pass(phi::handle::pipeline_state) && = delete;

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -135,12 +135,12 @@ public:
     /// (deferred freeing it afterwards)
     void auto_upload_texture_data(cc::span<std::byte const> texture_data, texture const& dest_texture);
 
-    void upload_texture_subresource(cc::span<std::byte const> texture_data,
-                                    unsigned row_size_bytes,
-                                    buffer const& upload_buffer,
-                                    unsigned buffer_offset_bytes,
-                                    texture const& dest_texture,
-                                    unsigned dest_subres_index);
+    size_t upload_texture_subresource(cc::span<std::byte const> texture_data,
+                                      unsigned row_size_bytes,
+                                      buffer const& upload_buffer,
+                                      unsigned buffer_offset_bytes,
+                                      texture const& dest_texture,
+                                      unsigned dest_subres_index);
 
     /// free a buffer once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(buffer const& buf) { free_deferred_after_submit(buf.res.handle); }

--- a/src/phantasm-renderer/Frame.hh
+++ b/src/phantasm-renderer/Frame.hh
@@ -67,13 +67,12 @@ public:
 
     void transition(buffer const& res, state target, shader_flags dependency = {});
     void transition(texture const& res, state target, shader_flags dependency = {});
-    void transition(render_target const& res, state target, shader_flags dependency = {});
     void transition(phi::handle::resource raw_resource, state target, shader_flags dependency = {});
 
     void barrier_uav(cc::span<phi::handle::resource const> resources);
 
     /// transition the backbuffer to present state and trigger a Context::present after this frame is submitted
-    void present_after_submit(render_target const& backbuffer, swapchain sc);
+    void present_after_submit(texture const& backbuffer, swapchain sc);
 
     //
     // commands
@@ -85,19 +84,10 @@ public:
     void copy(buffer const& src, texture const& dest, size_t src_offset = 0, unsigned dest_mip_index = 0, unsigned dest_array_index = 0);
 
     /// copy texture to buffer
-    void copy(render_target const& src, buffer const& dest, size_t dest_offset = 0);
+    void copy(texture const& src, buffer const& dest, size_t dest_offset = 0);
 
     /// copies all array slices at the given MIP level from src to dest
     void copy(texture const& src, texture const& dest, unsigned mip_index = 0);
-
-    /// copies MIP level 0, array slice 0 from src to dest
-    void copy(texture const& src, render_target const& dest);
-
-    /// copies src to MIP level 0, array slice 0 of dest
-    void copy(render_target const& src, texture const& dest);
-
-    /// copies contents of src to dest
-    void copy(render_target const& src, render_target const& dest);
 
     /// copy textures specifying all details of the operation
     void copy_subsection(texture const& src,
@@ -109,9 +99,8 @@ public:
                          unsigned num_array_slices,
                          tg::isize2 dest_size);
 
-    /// resolve a multisampled render target to a texture or different RT
-    void resolve(render_target const& src, texture const& dest);
-    void resolve(render_target const& src, render_target const& dest);
+    /// resolve a multisampled texture
+    void resolve(texture const& src, texture const& dest);
 
     /// write a timestamp to a query in a given (timestamp) query range
     void write_timestamp(query_range const& query_range, unsigned index);
@@ -138,7 +127,7 @@ public:
     /// expects upload buffer with sufficient size (see Context::calculate_texture_upload_size)
     void upload_texture_data(cc::span<std::byte const> texture_data, buffer const& upload_buffer, texture const& dest_texture);
 
-    /// creates a suitable upload buffer and calls upload_texutre_data
+    /// creates a suitable upload buffer and calls upload_texture_data
     /// (deferred freeing it afterwards)
     void auto_upload_texture_data(cc::span<std::byte const> texture_data, texture const& dest_texture);
 
@@ -157,9 +146,6 @@ public:
 
     /// free a texture once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(texture const& tex) { free_deferred_after_submit(tex.res.handle); }
-
-    /// free a render target once no longer in flight AFTER this frame was submitted/discarded
-    void free_deferred_after_submit(render_target const& rt) { free_deferred_after_submit(rt.res.handle); }
 
     /// free a resource once no longer in flight AFTER this frame was submitted/discarded
     void free_deferred_after_submit(raw_resource const& res) { free_deferred_after_submit(res.handle); }
@@ -233,7 +219,7 @@ public:
 
     // private
 private:
-    static void addRenderTargetToFramebuffer(phi::cmd::begin_render_pass& bcmd, int& num_samples, render_target const& rt);
+    static void addRenderTargetToFramebuffer(phi::cmd::begin_render_pass& bcmd, int& num_samples, texture const& rt);
 
     void flushPendingTransitions();
 

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -96,12 +96,28 @@ public:
         if (phi::util::is_depth_format(rt.info.format))
         {
             _cmd.depth_target = phi::cmd::begin_render_pass::depth_stencil_info{{}, 1.f, 0, phi::rt_clear_type::load};
-            _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index, 1u, array_index);
+
+            if (array_index > 0)
+            {
+                _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+            }
+            else
+            {
+                _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+            }
         }
         else
         {
             _cmd.render_targets.push_back(phi::cmd::begin_render_pass::render_target_info{{}, {0.f, 0.f, 0.f, 1.f}, phi::rt_clear_type::load});
-            _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index, 1u, array_index);
+
+            if (array_index > 0)
+            {
+                _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+            }
+            else
+            {
+                _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+            }
         }
         adjust_config_for_render_target(rt);
         return *this;
@@ -114,7 +130,15 @@ public:
         CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "invoked clear_target color variant with a depth render target");
 
         _cmd.render_targets.push_back(phi::cmd::begin_render_pass::render_target_info{{}, {clear_r, clear_g, clear_b, clear_a}, phi::rt_clear_type::clear});
-        _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index, 1u, array_index);
+        if (array_index > 0)
+        {
+            _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+        }
+        else
+        {
+            _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+        }
+
         adjust_config_for_render_target(rt);
         return *this;
     }
@@ -125,7 +149,15 @@ public:
         CC_ASSERT(phi::util::is_depth_format(rt.info.format) && "invoked clear_target depth variant with a non-depth render target");
 
         _cmd.depth_target = phi::cmd::begin_render_pass::depth_stencil_info{{}, clear_depth, clear_stencil, phi::rt_clear_type::clear};
-        _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index, 1u, array_index);
+
+        if (array_index > 0)
+        {
+            _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+        }
+        else
+        {
+            _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+        }
         adjust_config_for_render_target(rt);
         return *this;
     }

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -6,13 +6,14 @@
 #include <phantasm-hardware-interface/commands.hh>
 
 #include <phantasm-renderer/GraphicsPass.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
 #include <phantasm-renderer/pass_info.hh>
 
 namespace pr::raii
 {
-class Framebuffer
+class PR_API Framebuffer
 {
 public:
     // lvalue-qualified as Framebuffer has to stay alive
@@ -85,7 +86,7 @@ private:
         = false; ///< whether mHashInfo contains blendstate overrides - this triggers asserts if using persisted PSOs as they are unaffected by these settings
 };
 
-struct framebuffer_builder
+struct PR_API framebuffer_builder
 {
 public:
     /// add a rendertarget to the framebuffer that loads is contents (ie. is not cleared)

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -94,19 +94,19 @@ struct PR_API framebuffer_builder
 {
 public:
     /// add a rendertarget to the framebuffer that loads is contents (ie. is not cleared)
-    [[nodiscard]] framebuffer_builder& loaded_target(render_target const& rt, uint32_t mip_index = 0u, uint32_t array_index = 0u)
+    [[nodiscard]] framebuffer_builder& loaded_target(texture const& rt, uint32_t mip_index = 0u, uint32_t array_index = 0u)
     {
-        if (phi::util::is_depth_format(rt.info.format))
+        if (phi::util::is_depth_format(rt.info.fmt))
         {
             _cmd.depth_target = phi::cmd::begin_render_pass::depth_stencil_info{{}, 1.f, 0, phi::rt_clear_type::load};
 
             if (array_index > 0)
             {
-                _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+                _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, array_index, 1u, mip_index);
             }
             else
             {
-                _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+                _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, mip_index);
             }
         }
         else
@@ -115,11 +115,11 @@ public:
 
             if (array_index > 0)
             {
-                _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+                _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, array_index, 1u, mip_index);
             }
             else
             {
-                _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+                _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, mip_index);
             }
         }
         adjust_config_for_render_target(rt);
@@ -128,18 +128,18 @@ public:
 
     /// add a rendertarget to the framebuffer that clears to a specified value
     [[nodiscard]] framebuffer_builder& cleared_target(
-        render_target const& rt, float clear_r = 0.f, float clear_g = 0.f, float clear_b = 0.f, float clear_a = 1.f, uint32_t mip_index = 0u, uint32_t array_index = 0u)
+        texture const& rt, float clear_r = 0.f, float clear_g = 0.f, float clear_b = 0.f, float clear_a = 1.f, uint32_t mip_index = 0u, uint32_t array_index = 0u)
     {
-        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "invoked clear_target color variant with a depth render target");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.fmt) && "invoked clear_target color variant with a depth render target");
 
         _cmd.render_targets.push_back(phi::cmd::begin_render_pass::render_target_info{{}, {clear_r, clear_g, clear_b, clear_a}, phi::rt_clear_type::clear});
         if (array_index > 0)
         {
-            _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+            _cmd.render_targets.back().rv.init_as_tex2d_array(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, array_index, 1u, mip_index);
         }
         else
         {
-            _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+            _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, mip_index);
         }
 
         adjust_config_for_render_target(rt);
@@ -147,19 +147,19 @@ public:
     }
 
     /// add a depth rendertarget to the framebuffer that clears to a specified value
-    [[nodiscard]] framebuffer_builder& cleared_depth(render_target const& rt, float clear_depth = 1.f, uint8_t clear_stencil = 0, uint32_t mip_index = 0u, uint32_t array_index = 0u)
+    [[nodiscard]] framebuffer_builder& cleared_depth(texture const& rt, float clear_depth = 1.f, uint8_t clear_stencil = 0, uint32_t mip_index = 0u, uint32_t array_index = 0u)
     {
-        CC_ASSERT(phi::util::is_depth_format(rt.info.format) && "invoked clear_target depth variant with a non-depth render target");
+        CC_ASSERT(phi::util::is_depth_format(rt.info.fmt) && "invoked clear_target depth variant with a non-depth render target");
 
         _cmd.depth_target = phi::cmd::begin_render_pass::depth_stencil_info{{}, clear_depth, clear_stencil, phi::rt_clear_type::clear};
 
         if (array_index > 0)
         {
-            _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.format, rt.info.num_samples > 1, array_index, 1u, mip_index);
+            _cmd.depth_target.rv.init_as_tex2d_array(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, array_index, 1u, mip_index);
         }
         else
         {
-            _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1, mip_index);
+            _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.fmt, rt.info.num_samples > 1, mip_index);
         }
         adjust_config_for_render_target(rt);
         return *this;
@@ -167,9 +167,9 @@ public:
 
     /// add a rendertarget to the framebuffer that loads is contents (ie. is not cleared), including a blend state override
     /// NOTE: blend state only applies to cached PSOs created from the framebuffer
-    [[nodiscard]] framebuffer_builder& loaded_target(render_target const& rt, pr::blend_state const& blend, uint32_t mip_index = 0u, uint32_t array_index = 0u)
+    [[nodiscard]] framebuffer_builder& loaded_target(texture const& rt, pr::blend_state const& blend, uint32_t mip_index = 0u, uint32_t array_index = 0u)
     {
-        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.fmt) && "cannot specify blend state for depth targets");
 
         (void)loaded_target(rt, mip_index, array_index);
         _has_custom_blendstate = true;
@@ -181,7 +181,7 @@ public:
 
     /// add a rendertarget to the framebuffer that clears to a specified value, including a blend state override
     /// NOTE: blend state only applies to cached PSOs created from the framebuffer
-    [[nodiscard]] framebuffer_builder& cleared_target(render_target const& rt,
+    [[nodiscard]] framebuffer_builder& cleared_target(texture const& rt,
                                                       pr::blend_state const& blend,
                                                       float clear_r = 0.f,
                                                       float clear_g = 0.f,
@@ -190,7 +190,7 @@ public:
                                                       uint32_t mip_index = 0u,
                                                       uint32_t array_index = 0u)
     {
-        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.fmt) && "cannot specify blend state for depth targets");
         (void)cleared_target(rt, clear_r, clear_g, clear_b, clear_a, mip_index, array_index);
         _has_custom_blendstate = true;
         auto& state = _blendstate_overrides.render_targets.back();
@@ -247,9 +247,9 @@ private:
         _cmd.set_null_depth_stencil();
     }
 
-    void adjust_config_for_render_target(render_target const& rt)
+    void adjust_config_for_render_target(texture const& rt)
     {
-        adjust_config_for_render_target(rt.info.num_samples, {rt.info.width, rt.info.height}, rt.info.format);
+        adjust_config_for_render_target(rt.info.num_samples, {rt.info.width, rt.info.height}, rt.info.fmt);
     }
 
     void adjust_config_for_render_target(uint32_t num_samples, tg::isize2 res, pr::format fmt)

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -48,7 +48,11 @@ public:
 
 public:
     Framebuffer(Framebuffer const&) = delete;
-    Framebuffer(Framebuffer&& rhs) noexcept : mParent(rhs.mParent) { rhs.mParent = nullptr; }
+    Framebuffer(Framebuffer&& rhs) noexcept
+      : mParent(rhs.mParent), mHashInfo(cc::move(rhs.mHashInfo)), mNumSamples(rhs.mNumSamples), mHasBlendstateOverrides(rhs.mHasBlendstateOverrides)
+    {
+        rhs.mParent = nullptr;
+    }
     Framebuffer& operator=(Framebuffer const&) = delete;
     Framebuffer& operator=(Framebuffer&& rhs) noexcept
     {
@@ -56,6 +60,9 @@ public:
         {
             destroy();
             mParent = rhs.mParent;
+            mHashInfo = cc::move(rhs.mHashInfo);
+            mNumSamples = rhs.mNumSamples;
+            mHasBlendstateOverrides = rhs.mHasBlendstateOverrides;
             rhs.mParent = nullptr;
         }
 
@@ -71,10 +78,11 @@ private:
     }
     void destroy();
 
-    Frame* mParent;
+    Frame* mParent = nullptr;
     framebuffer_info mHashInfo;
-    int mNumSamples; ///< amount of multisamples of the rendertargets, inferred. unknown (-1) on some paths
-    bool mHasBlendstateOverrides; ///< whether mHashInfo contains blendstate overrides - this triggers asserts if using persisted PSOs as they are unaffected by these settings
+    int mNumSamples = 0; ///< amount of multisamples of the rendertargets, inferred. unknown (-1) on some paths
+    bool mHasBlendstateOverrides
+        = false; ///< whether mHashInfo contains blendstate overrides - this triggers asserts if using persisted PSOs as they are unaffected by these settings
 };
 
 struct framebuffer_builder

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -4,6 +4,7 @@
 #include <clean-core/utility.hh>
 
 #include <phantasm-hardware-interface/commands.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 
 #include <phantasm-renderer/GraphicsPass.hh>
 #include <phantasm-renderer/common/api.hh>
@@ -92,7 +93,7 @@ public:
     /// add a rendertarget to the framebuffer that loads is contents (ie. is not cleared)
     [[nodiscard]] framebuffer_builder& loaded_target(render_target const& rt)
     {
-        if (phi::is_depth_format(rt.info.format))
+        if (phi::util::is_depth_format(rt.info.format))
         {
             _cmd.set_2d_depth_stencil(rt.res.handle, rt.info.format, phi::rt_clear_type::load, rt.info.num_samples > 1);
         }
@@ -107,7 +108,7 @@ public:
     /// add a rendertarget to the framebuffer that clears to a specified value
     [[nodiscard]] framebuffer_builder& cleared_target(render_target const& rt, float clear_r = 0.f, float clear_g = 0.f, float clear_b = 0.f, float clear_a = 1.f)
     {
-        CC_ASSERT(!phi::is_depth_format(rt.info.format) && "invoked clear_target color variant with a depth render target");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "invoked clear_target color variant with a depth render target");
         _cmd.render_targets.push_back(phi::cmd::begin_render_pass::render_target_info{{}, {clear_r, clear_g, clear_b, clear_a}, phi::rt_clear_type::clear});
         _cmd.render_targets.back().rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
         adjust_config(rt);
@@ -117,7 +118,7 @@ public:
     /// add a depth rendertarget to the framebuffer that clears to a specified value
     [[nodiscard]] framebuffer_builder& cleared_depth(render_target const& rt, float clear_depth = 1.f, uint8_t clear_stencil = 0)
     {
-        CC_ASSERT(phi::is_depth_format(rt.info.format) && "invoked clear_target depth variant with a non-depth render target");
+        CC_ASSERT(phi::util::is_depth_format(rt.info.format) && "invoked clear_target depth variant with a non-depth render target");
         _cmd.depth_target = phi::cmd::begin_render_pass::depth_stencil_info{{}, clear_depth, clear_stencil, phi::rt_clear_type::clear};
         _cmd.depth_target.rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
         adjust_config(rt);
@@ -128,7 +129,7 @@ public:
     /// NOTE: blend state only applies to cached PSOs created from the framebuffer
     [[nodiscard]] framebuffer_builder& loaded_target(render_target const& rt, pr::blend_state const& blend)
     {
-        CC_ASSERT(!phi::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
         (void)loaded_target(rt);
         _has_custom_blendstate = true;
         auto& state = _blendstate_overrides.render_targets.back();
@@ -142,7 +143,7 @@ public:
     [[nodiscard]] framebuffer_builder& cleared_target(
         render_target const& rt, pr::blend_state const& blend, float clear_r = 0.f, float clear_g = 0.f, float clear_b = 0.f, float clear_a = 1.f)
     {
-        CC_ASSERT(!phi::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
+        CC_ASSERT(!phi::util::is_depth_format(rt.info.format) && "cannot specify blend state for depth targets");
         (void)cleared_target(rt, clear_r, clear_g, clear_b, clear_a);
         _has_custom_blendstate = true;
         auto& state = _blendstate_overrides.render_targets.back();
@@ -211,7 +212,7 @@ private:
         }
 
         // keep blenstate override RTs consistent in size
-        if (!phi::is_depth_format(rt.info.format))
+        if (!phi::util::is_depth_format(rt.info.format))
             _blendstate_overrides.add_render_target(rt.info.format);
     }
 

--- a/src/phantasm-renderer/Framebuffer.hh
+++ b/src/phantasm-renderer/Framebuffer.hh
@@ -41,6 +41,9 @@ public:
     /// requires #num_drawcalls contiguously recorded drawcalls
     void sort_drawcalls_by_pso(unsigned num_drawcalls);
 
+    /// returns the parent frame
+    Frame& get_frame() const { return *mParent; }
+
 public:
     // redirect intuitive misuses
     [[deprecated("pr::raii::Framebuffer must stay alive while passes are used")]] GraphicsPass make_pass(graphics_pipeline_state const&) && = delete;

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -4,18 +4,18 @@
 
 #include "Frame.hh"
 
-void pr::raii::GraphicsPass::draw(unsigned num_vertices, unsigned num_instances)
+void pr::raii::GraphicsPass::draw(uint32_t num_vertices, uint32_t num_instances)
 {
     draw(phi::handle::null_resource, phi::handle::null_resource, num_vertices, num_instances);
 }
 
-void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, unsigned num_instances)
+void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, uint32_t num_instances)
 {
     CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
     draw(vertex_buffer.res.handle, phi::handle::null_resource, vertex_buffer.info.size_bytes / vertex_buffer.info.stride_bytes, num_instances);
 }
 
-void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer, unsigned num_instances)
+void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer, uint32_t num_instances)
 {
     CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
     CC_ASSERT(index_buffer.info.stride_bytes > 0 && "index buffer not strided");
@@ -23,7 +23,7 @@ void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buf
     draw(vertex_buffer.res.handle, index_buffer.res.handle, index_buffer.info.size_bytes / index_buffer.info.stride_bytes, num_instances);
 }
 
-void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices, unsigned num_instances)
+void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, uint32_t num_indices, uint32_t num_instances)
 {
     CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at drawcall submission");
 
@@ -35,7 +35,7 @@ void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::hand
     mParent->passOnDraw(mCmd);
 }
 
-void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, const pr::buffer& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset)
+void raii::GraphicsPass::draw_indirect(phi::handle::resource argument_buffer, phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes)
 {
     CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at drawcall submission");
 
@@ -43,13 +43,23 @@ void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, co
     std::memcpy(dcmd.root_constants, mCmd.root_constants, sizeof(dcmd.root_constants));
     std::memcpy(dcmd.shader_arguments.data(), mCmd.shader_arguments.data(), sizeof(dcmd.shader_arguments));
     dcmd.pipeline_state = mCmd.pipeline_state;
-    dcmd.indirect_argument_buffer = argument_buffer.res.handle;
-    dcmd.argument_buffer_offset_bytes = arg_buffer_offset;
+    dcmd.indirect_argument_buffer = argument_buffer;
+    dcmd.argument_buffer_offset_bytes = arg_buffer_offset_bytes;
     dcmd.num_arguments = num_args;
-    dcmd.vertex_buffer = vertex_buffer.res.handle;
-    dcmd.index_buffer = phi::handle::null_resource;
+    dcmd.vertex_buffer = vertex_buffer;
+    dcmd.index_buffer = index_buffer;
 
     mParent->write_raw_cmd(dcmd);
+}
+
+void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, const pr::buffer& vertex_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes)
+{
+    draw_indirect(argument_buffer.res.handle, vertex_buffer.res.handle, phi::handle::null_resource, num_args, arg_buffer_offset_bytes);
+}
+
+void pr::raii::GraphicsPass::draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes)
+{
+    draw_indirect(argument_buffer.res.handle, vertex_buffer.res.handle, index_buffer.res.handle, num_args, arg_buffer_offset_bytes);
 }
 
 void pr::raii::GraphicsPass::add_cached_argument(const pr::argument& arg, phi::handle::resource cbv, uint32_t cbv_offset)

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -25,6 +25,8 @@ void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buf
 
 void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices, unsigned num_instances)
 {
+    CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at drawcall submission");
+
     mCmd.vertex_buffer = vertex_buffer;
     mCmd.index_buffer = index_buffer;
     mCmd.num_instances = num_instances;
@@ -35,6 +37,8 @@ void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::hand
 
 void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, const pr::buffer& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset)
 {
+    CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at drawcall submission");
+
     phi::cmd::draw_indirect dcmd;
     std::memcpy(dcmd.root_constants, mCmd.root_constants, sizeof(dcmd.root_constants));
     std::memcpy(dcmd.shader_arguments.data(), mCmd.shader_arguments.data(), sizeof(dcmd.shader_arguments));

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -27,7 +27,7 @@ void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::hand
 {
     CC_ASSERT(mCmd.pipeline_state.is_valid() && "PSO is invalid at drawcall submission");
 
-    mCmd.vertex_buffer = vertex_buffer;
+    mCmd.vertex_buffers[0] = vertex_buffer;
     mCmd.index_buffer = index_buffer;
     mCmd.num_instances = num_instances;
     mCmd.num_indices = num_indices;
@@ -46,7 +46,7 @@ void raii::GraphicsPass::draw_indirect(phi::handle::resource argument_buffer, ph
     dcmd.indirect_argument_buffer = argument_buffer;
     dcmd.argument_buffer_offset_bytes = arg_buffer_offset_bytes;
     dcmd.num_arguments = num_args;
-    dcmd.vertex_buffer = vertex_buffer;
+    dcmd.vertex_buffers[0] = vertex_buffer;
     dcmd.index_buffer = index_buffer;
 
     mParent->write_raw_cmd(dcmd);

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -4,27 +4,30 @@
 
 #include "Frame.hh"
 
-void pr::raii::GraphicsPass::draw(unsigned num_vertices) { draw(phi::handle::null_resource, phi::handle::null_resource, num_vertices); }
-
-void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer)
+void pr::raii::GraphicsPass::draw(unsigned num_vertices, unsigned num_instances)
 {
-    CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
-    draw(vertex_buffer.res.handle, phi::handle::null_resource, vertex_buffer.info.size_bytes / vertex_buffer.info.stride_bytes);
+    draw(phi::handle::null_resource, phi::handle::null_resource, num_vertices, num_instances);
 }
 
-void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer)
+void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, unsigned num_instances)
+{
+    CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
+    draw(vertex_buffer.res.handle, phi::handle::null_resource, vertex_buffer.info.size_bytes / vertex_buffer.info.stride_bytes, num_instances);
+}
+
+void pr::raii::GraphicsPass::draw(const pr::buffer& vertex_buffer, const pr::buffer& index_buffer, unsigned num_instances)
 {
     CC_ASSERT(vertex_buffer.info.stride_bytes > 0 && "vertex buffer not strided");
     CC_ASSERT(index_buffer.info.stride_bytes > 0 && "index buffer not strided");
     CC_ASSERT(index_buffer.info.stride_bytes <= 4 && "index buffer stride unusually large - switched up vertex and index buffer?");
-    draw(vertex_buffer.res.handle, index_buffer.res.handle, index_buffer.info.size_bytes / index_buffer.info.stride_bytes);
+    draw(vertex_buffer.res.handle, index_buffer.res.handle, index_buffer.info.size_bytes / index_buffer.info.stride_bytes, num_instances);
 }
 
-void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices)
+void pr::raii::GraphicsPass::draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices, unsigned num_instances)
 {
     mCmd.vertex_buffer = vertex_buffer;
     mCmd.index_buffer = index_buffer;
-
+    mCmd.num_instances = num_instances;
     mCmd.num_indices = num_indices;
 
     mParent->passOnDraw(mCmd);

--- a/src/phantasm-renderer/GraphicsPass.cc
+++ b/src/phantasm-renderer/GraphicsPass.cc
@@ -52,15 +52,8 @@ void pr::raii::GraphicsPass::draw_indirect(const pr::buffer& argument_buffer, co
     mParent->write_raw_cmd(dcmd);
 }
 
-void pr::raii::GraphicsPass::add_argument(const pr::argument& arg)
+void pr::raii::GraphicsPass::add_cached_argument(const pr::argument& arg, phi::handle::resource cbv, uint32_t cbv_offset)
 {
     ++mArgNum;
-    mCmd.add_shader_arg(phi::handle::null_resource, 0, mParent->passAcquireGraphicsShaderView(arg));
-}
-
-
-void pr::raii::GraphicsPass::add_argument(const pr::argument& arg, const pr::buffer& constant_buffer, uint32_t constant_buffer_offset)
-{
-    ++mArgNum;
-    mCmd.add_shader_arg(constant_buffer.res.handle, constant_buffer_offset, mParent->passAcquireGraphicsShaderView(arg));
+    mCmd.add_shader_arg(cbv, cbv_offset, mParent->passAcquireGraphicsShaderView(arg));
 }

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -60,18 +60,33 @@ public:
         return p;
     }
 
+    // draw without vertices
     void draw(uint32_t num_vertices, uint32_t num_instances = 1);
+
+    // draw vertices
     void draw(buffer const& vertex_buffer, uint32_t num_instances = 1);
+
+    // indexed draw
     void draw(buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_instances = 1);
+
+    // indexed draw with raw handles
     void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, uint32_t num_indices, uint32_t num_instances = 1);
 
+    // indexed draw with raw handles and up to 4 vertex buffers
+    void draw(cc::span<phi::handle::resource const> vertex_buffers, phi::handle::resource index_buffer, uint32_t num_indices, uint32_t num_instances = 1);
+
+    // indirect draw
+    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
+
+    // indirect indexed draw
+    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
+
+    // indirect draw with raw handles
     void draw_indirect(phi::handle::resource argument_buffer,
                        phi::handle::resource vertex_buffer,
                        phi::handle::resource index_buffer,
                        uint32_t num_args,
                        uint32_t arg_buffer_offset_bytes = 0);
-    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
-    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
 
     void set_offset(int vertex_offset, uint32_t index_offset = 0);
 

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -28,7 +28,7 @@ public:
 
     void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset = 0);
 
-    void set_offset(unsigned vertex_offset, unsigned index_offset = 0);
+    void set_offset(int vertex_offset, unsigned index_offset = 0);
 
     void set_scissor(tg::iaabb2 scissor) { mCmd.scissor = scissor; }
     void set_scissor(int left, int top, int right, int bot) { mCmd.scissor = tg::iaabb2({left, top}, {right, bot}); }
@@ -52,7 +52,8 @@ public:
     /// NOTE: advanced usage
     void reset_pipeline_state(phi::handle::pipeline_state pso) { mCmd.pipeline_state = pso; }
 
-    GraphicsPass(GraphicsPass&& rhs) = default;
+    GraphicsPass(GraphicsPass const&) = delete;
+    GraphicsPass(GraphicsPass&& rhs) noexcept = default;
 
 private:
     friend class Framebuffer;
@@ -86,7 +87,7 @@ private:
 
 // inline implementation
 
-inline void GraphicsPass::set_offset(unsigned vertex_offset, unsigned index_offset)
+inline void GraphicsPass::set_offset(int vertex_offset, unsigned index_offset)
 {
     mCmd.vertex_offset = vertex_offset;
     mCmd.index_offset = index_offset;

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -3,6 +3,7 @@
 #include <phantasm-hardware-interface/commands.hh>
 
 #include <phantasm-renderer/argument.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/fwd.hh>
 #include <phantasm-renderer/resource_types.hh>
 
@@ -10,7 +11,7 @@ namespace pr::raii
 {
 class Frame;
 
-class GraphicsPass
+class PR_API GraphicsPass
 {
 public:
     template <class... Args>

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -60,23 +60,29 @@ public:
         return p;
     }
 
-    void draw(unsigned num_vertices, unsigned num_instances = 1);
-    void draw(buffer const& vertex_buffer, unsigned num_instances = 1);
-    void draw(buffer const& vertex_buffer, buffer const& index_buffer, unsigned num_instances = 1);
-    void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices, unsigned num_instances = 1);
+    void draw(uint32_t num_vertices, uint32_t num_instances = 1);
+    void draw(buffer const& vertex_buffer, uint32_t num_instances = 1);
+    void draw(buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_instances = 1);
+    void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, uint32_t num_indices, uint32_t num_instances = 1);
 
-    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset = 0);
+    void draw_indirect(phi::handle::resource argument_buffer,
+                       phi::handle::resource vertex_buffer,
+                       phi::handle::resource index_buffer,
+                       uint32_t num_args,
+                       uint32_t arg_buffer_offset_bytes = 0);
+    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
+    void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, buffer const& index_buffer, uint32_t num_args, uint32_t arg_buffer_offset_bytes = 0);
 
-    void set_offset(int vertex_offset, unsigned index_offset = 0);
+    void set_offset(int vertex_offset, uint32_t index_offset = 0);
 
     void set_scissor(tg::iaabb2 scissor) { mCmd.scissor = scissor; }
     void set_scissor(int left, int top, int right, int bot) { mCmd.scissor = tg::iaabb2({left, top}, {right, bot}); }
     void unset_scissor() { mCmd.scissor = tg::iaabb2(-1, -1); }
 
-    void set_constant_buffer(buffer const& constant_buffer, unsigned offset = 0);
-    void set_constant_buffer(phi::handle::resource raw_cbv, unsigned offset = 0);
+    void set_constant_buffer(buffer const& constant_buffer, uint32_t offset = 0);
+    void set_constant_buffer(phi::handle::resource raw_cbv, uint32_t offset = 0);
 
-    void set_constant_buffer_offset(unsigned offset);
+    void set_constant_buffer_offset(uint32_t offset);
 
 
     template <class T>
@@ -101,7 +107,7 @@ private:
 
 private:
     // internal re-bind ctor
-    GraphicsPass(Frame* parent, phi::cmd::draw const& cmd, unsigned arg_i) : mParent(parent), mCmd(cmd), mArgNum(arg_i) {}
+    GraphicsPass(Frame* parent, phi::cmd::draw const& cmd, uint32_t arg_i) : mParent(parent), mCmd(cmd), mArgNum(arg_i) {}
 
 private:
     // persisted, raw phi
@@ -114,30 +120,30 @@ private:
     Frame* mParent = nullptr;
     phi::cmd::draw mCmd;
     // index of owning argument - 1, 0 means no arguments existing
-    unsigned mArgNum = 0;
+    uint32_t mArgNum = 0;
 };
 
 // inline implementation
 
-inline void GraphicsPass::set_offset(int vertex_offset, unsigned index_offset)
+inline void GraphicsPass::set_offset(int vertex_offset, uint32_t index_offset)
 {
     mCmd.vertex_offset = vertex_offset;
     mCmd.index_offset = index_offset;
 }
 
-inline void GraphicsPass::set_constant_buffer(const buffer& constant_buffer, unsigned offset)
+inline void GraphicsPass::set_constant_buffer(const buffer& constant_buffer, uint32_t offset)
 {
     set_constant_buffer(constant_buffer.res.handle, offset);
 }
 
-inline void GraphicsPass::set_constant_buffer(phi::handle::resource raw_cbv, unsigned offset)
+inline void GraphicsPass::set_constant_buffer(phi::handle::resource raw_cbv, uint32_t offset)
 {
     CC_ASSERT(mArgNum != 0 && "Attempted to set_constant_buffer on a GraphicsPass without prior bind");
     mCmd.shader_arguments[uint8_t(mArgNum - 1)].constant_buffer = raw_cbv;
     mCmd.shader_arguments[uint8_t(mArgNum - 1)].constant_buffer_offset = offset;
 }
 
-inline void GraphicsPass::set_constant_buffer_offset(unsigned offset)
+inline void GraphicsPass::set_constant_buffer_offset(uint32_t offset)
 {
     CC_ASSERT(mArgNum != 0 && "Attempted to set_constant_buffer_offset on a GraphicsPass without prior bind");
     mCmd.shader_arguments[uint8_t(mArgNum - 1)].constant_buffer_offset = offset;

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -21,10 +21,10 @@ public:
         return p;
     }
 
-    void draw(unsigned num_vertices);
-    void draw(buffer const& vertex_buffer);
-    void draw(buffer const& vertex_buffer, buffer const& index_buffer);
-    void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices);
+    void draw(unsigned num_vertices, unsigned num_instances = 1);
+    void draw(buffer const& vertex_buffer, unsigned num_instances = 1);
+    void draw(buffer const& vertex_buffer, buffer const& index_buffer, unsigned num_instances = 1);
+    void draw(phi::handle::resource vertex_buffer, phi::handle::resource index_buffer, unsigned num_indices, unsigned num_instances = 1);
 
     void draw_indirect(buffer const& argument_buffer, buffer const& vertex_buffer, unsigned num_args, unsigned arg_buffer_offset = 0);
 

--- a/src/phantasm-renderer/GraphicsPass.hh
+++ b/src/phantasm-renderer/GraphicsPass.hh
@@ -46,10 +46,10 @@ public:
 
     // cache-access variants
     // hits a OS mutex
-    [[nodiscard]] GraphicsPass bind(argument const& arg)
+    [[nodiscard]] GraphicsPass bind(argument const& arg, phi::handle::resource constant_buffer = phi::handle::null_resource, uint32_t constant_buffer_offset = 0)
     {
         GraphicsPass p = {mParent, mCmd, mArgNum};
-        p.add_cached_argument(arg, phi::handle::null_resource, 0);
+        p.add_cached_argument(arg, constant_buffer, constant_buffer_offset);
         return p;
     }
 

--- a/src/phantasm-renderer/argument.cc
+++ b/src/phantasm-renderer/argument.cc
@@ -31,6 +31,8 @@ void pr::argument::fill_default_srv(phi::resource_view& new_rv, const pr::textur
     {
         if (img.info.depth_or_array_size == 6)
             new_rv.dimension = phi::resource_view_dimension::texturecube;
+        else if (img.info.num_samples > 1)
+            new_rv.dimension = img.info.depth_or_array_size > 1 ? phi::resource_view_dimension::texture2d_ms_array : phi::resource_view_dimension::texture2d_ms;
         else
             new_rv.dimension = img.info.depth_or_array_size > 1 ? phi::resource_view_dimension::texture2d_array : phi::resource_view_dimension::texture2d;
 

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -4,8 +4,8 @@
 
 #include <phantasm-hardware-interface/arguments.hh>
 
-#include <phantasm-renderer/common/hashable_storage.hh>
 #include <phantasm-renderer/common/api.hh>
+#include <phantasm-renderer/common/hashable_storage.hh>
 #include <phantasm-renderer/common/state_info.hh>
 
 #include <phantasm-renderer/enums.hh>

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -101,10 +101,10 @@ public:
     }
 
     /// add a default-configured structured buffer SRV
-    void add(buffer const& buffer)
+    void add(buffer const& buffer, uint32_t element_start = 0u)
     {
         phi::resource_view new_rv;
-        pr::argument::fill_default_srv(new_rv, buffer);
+        pr::argument::fill_default_srv(new_rv, buffer, element_start);
         _add_srv(new_rv, buffer.res.guid);
     }
 
@@ -168,7 +168,9 @@ public:
     static void fill_default_srv(phi::resource_view& new_rv, pr::buffer const& buf, uint32_t element_start = 0u)
     {
         CC_ASSERT(buf.info.stride_bytes > 0 && "buffer used as SRV has no stride, pass a stride during creation");
-        new_rv.init_as_structured_buffer(buf.res.handle, buf.info.size_bytes / buf.info.stride_bytes, buf.info.stride_bytes, element_start);
+        uint32_t const num_elems = buf.info.size_bytes / buf.info.stride_bytes;
+        CC_ASSERT(element_start < num_elems && "element_start is OOB");
+        new_rv.init_as_structured_buffer(buf.res.handle, num_elems - element_start, buf.info.stride_bytes, element_start);
     }
 
     static void fill_default_uav(phi::resource_view& new_rv, pr::texture const& img, unsigned mip_start, unsigned mip_size);

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -129,8 +129,8 @@ public:
 
     void add_sampler(pr::sampler_config const& config)
     {
-        CC_ASSERT_MSG(!_info.get().uavs.full(), "pr::argument samplers full\ncache-access arguments are fixed size,\n"
-                                                "use persistent prebuilt_arguments from Context::build_argument() instead");
+        CC_ASSERT_MSG(!_info.get().samplers.full(), "pr::argument samplers full\ncache-access arguments are fixed size,\n"
+                                                    "use persistent prebuilt_arguments from Context::build_argument() instead");
 
         _info.get().samplers.push_back(config);
     }

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -156,6 +156,13 @@ public:
     unsigned get_num_uavs() const { return unsigned(_info.get().uavs.size()); }
     unsigned get_num_samplers() const { return unsigned(_info.get().samplers.size()); }
 
+    void clear()
+    {
+        _info.get().srvs.clear();
+        _info.get().uavs.clear();
+        _info.get().samplers.clear();
+    }
+
     static void fill_default_srv(phi::resource_view& new_rv, pr::texture const& img, unsigned mip_start, unsigned mip_size);
 
     static void fill_default_srv(phi::resource_view& new_rv, pr::buffer const& buf, uint32_t element_start = 0u)

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -85,10 +85,10 @@ struct PR_API argument
 {
 public:
     /// add a default-configured texture SRV
-    void add(texture const& img)
+    void add(texture const& img, uint32_t mip_start = 0, uint32_t mip_size = uint32_t(-1))
     {
         phi::resource_view new_rv;
-        fill_default_srv(new_rv, img, 0, unsigned(-1));
+        fill_default_srv(new_rv, img, mip_start, mip_size);
         _add_srv(new_rv, img.res.guid);
     }
 
@@ -104,10 +104,10 @@ public:
     void add(resource_view_info const& rvi) { _add_srv(rvi.rv, rvi.guid); }
 
     /// add a default-configured texture UAV
-    void add_mutable(texture const& img)
+    void add_mutable(texture const& img, uint32_t mip_start = 0, uint32_t mip_size = uint32_t(-1))
     {
         phi::resource_view new_rv;
-        fill_default_uav(new_rv, img, 0, unsigned(-1));
+        fill_default_uav(new_rv, img, mip_start, mip_size);
         _add_uav(new_rv, img.res.guid);
     }
 

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -56,19 +56,19 @@ struct PR_API resource_view_info
     uint64_t guid;
 };
 
-[[nodiscard]] inline resource_view_info resource_view_2d(texture const& tex, unsigned mip_start = 0, unsigned mip_size = unsigned(-1))
+[[nodiscard]] inline resource_view_info resource_view_2d(texture const& tex, unsigned mip_index = 0)
 {
     resource_view_info res;
     res.guid = tex.res.guid;
-    res.rv.init_as_tex2d(tex.res.handle, tex.info.fmt, false, mip_start, mip_size);
+    res.rv.init_as_tex2d(tex.res.handle, tex.info.fmt, false, mip_index);
     return res;
 }
 
-[[nodiscard]] inline resource_view_info resource_view_2d(render_target const& tex, unsigned mip_start = 0, unsigned mip_size = unsigned(-1))
+[[nodiscard]] inline resource_view_info resource_view_2d(render_target const& tex, unsigned mip_index = 0)
 {
     resource_view_info res;
     res.guid = tex.res.guid;
-    res.rv.init_as_tex2d(tex.res.handle, tex.info.format, false, mip_start, mip_size);
+    res.rv.init_as_tex2d(tex.res.handle, tex.info.format, false, mip_index);
     return res;
 }
 

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -5,6 +5,7 @@
 #include <phantasm-hardware-interface/arguments.hh>
 
 #include <phantasm-renderer/common/hashable_storage.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/common/state_info.hh>
 
 #include <phantasm-renderer/enums.hh>
@@ -13,7 +14,7 @@
 
 namespace pr
 {
-struct resource_view_info
+struct PR_API resource_view_info
 {
     resource_view_info& format(pr::format fmt)
     {
@@ -88,7 +89,7 @@ struct resource_view_info
 }
 
 // fixed size, hashable, no raw resources allowed
-struct argument
+struct PR_API argument
 {
 public:
     /// add a default-configured texture SRV
@@ -192,7 +193,7 @@ struct prebuilt_argument
 using auto_prebuilt_argument = auto_destroyer<prebuilt_argument, auto_mode::guard>;
 
 // builder, only received directly from Context, can grow indefinitely in size, not hashable
-struct argument_builder
+struct PR_API argument_builder
 {
 public:
     //

--- a/src/phantasm-renderer/argument.hh
+++ b/src/phantasm-renderer/argument.hh
@@ -64,14 +64,6 @@ struct PR_API resource_view_info
     return res;
 }
 
-[[nodiscard]] inline resource_view_info resource_view_2d(render_target const& tex, unsigned mip_index = 0)
-{
-    resource_view_info res;
-    res.guid = tex.res.guid;
-    res.rv.init_as_tex2d(tex.res.handle, tex.info.format, false, mip_index);
-    return res;
-}
-
 [[nodiscard]] inline resource_view_info resource_view_cube(texture const& tex)
 {
     resource_view_info res;
@@ -108,9 +100,6 @@ public:
         _add_srv(new_rv, buffer.res.guid);
     }
 
-    /// add a default-configured 2D texture SRV
-    void add(render_target const& rt) { _add_srv(phi::resource_view::tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1), rt.res.guid); }
-
     /// add a configured SRV
     void add(resource_view_info const& rvi) { _add_srv(rvi.rv, rvi.guid); }
 
@@ -128,12 +117,6 @@ public:
         CC_ASSERT(buffer.info.stride_bytes > 0 && "buffer used as UAV has no stride, pass a stride during creation");
         _add_uav(phi::resource_view::structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes),
                  buffer.res.guid);
-    }
-
-    /// add a default-configured 2D texture UAV
-    void add_mutable(render_target const& rt)
-    {
-        _add_uav(phi::resource_view::tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1), rt.res.guid);
     }
 
     /// add a configured UAV
@@ -226,12 +209,6 @@ public:
         pr::argument::fill_default_srv(new_rv, buffer);
         return *this;
     }
-    argument_builder& add(render_target const& rt)
-    {
-        auto& new_rv = _srvs.emplace_back();
-        new_rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
-        return *this;
-    }
     argument_builder& add(resource_view_info const& rvi)
     {
         _srvs.push_back(rvi.rv);
@@ -257,12 +234,6 @@ public:
         CC_ASSERT(buffer.info.stride_bytes > 0 && "buffer used as UAV argument has no stride, pass a stride during creation");
         auto& new_rv = _uavs.emplace_back();
         new_rv.init_as_structured_buffer(buffer.res.handle, buffer.info.size_bytes / buffer.info.stride_bytes, buffer.info.stride_bytes);
-        return *this;
-    }
-    argument_builder& add_mutable(render_target const& rt)
-    {
-        auto& new_rv = _uavs.emplace_back();
-        new_rv.init_as_tex2d(rt.res.handle, rt.info.format, rt.info.num_samples > 1);
         return *this;
     }
     argument_builder& add_mutable(resource_view_info const& rvi)

--- a/src/phantasm-renderer/common/api.hh
+++ b/src/phantasm-renderer/common/api.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <clean-core/macros.hh>
+
+#ifdef CC_OS_WINDOWS
+
+#ifdef PR_BUILD_DLL
+
+#ifdef PR_DLL
+#define PR_API __declspec(dllexport)
+#else
+#define PR_API __declspec(dllimport)
+#endif
+
+#else
+#define PR_API
+#endif
+
+#else
+#define PR_API
+#endif

--- a/src/phantasm-renderer/common/gpu_epoch_tracker.hh
+++ b/src/phantasm-renderer/common/gpu_epoch_tracker.hh
@@ -3,6 +3,8 @@
 #include <phantasm-hardware-interface/fwd.hh>
 #include <phantasm-hardware-interface/types.hh>
 
+#include <phantasm-renderer/common/api.hh>
+
 namespace pr
 {
 using gpu_epoch_t = uint64_t;

--- a/src/phantasm-renderer/common/resource_info.hh
+++ b/src/phantasm-renderer/common/resource_info.hh
@@ -6,21 +6,15 @@
 
 namespace pr
 {
-using render_target_info = phi::arg::create_render_target_info;
-using texture_info = phi::arg::create_texture_info;
-using buffer_info = phi::arg::create_buffer_info;
-using generic_resource_info = phi::arg::create_resource_info;
+using texture_info = phi::arg::texture_description;
+using buffer_info = phi::arg::buffer_description;
+using generic_resource_info = phi::arg::resource_description;
 
 struct resource_info_hasher
 {
-    constexpr size_t operator()(render_target_info const& rt) const noexcept
-    {
-        return cc::make_hash(rt.format, rt.width, rt.height, rt.num_samples, rt.array_size, rt.clear_value);
-    }
-
     constexpr size_t operator()(texture_info const& t) const noexcept
     {
-        return cc::make_hash(t.fmt, t.dim, t.allow_uav, t.width, t.height, t.depth_or_array_size, t.num_mips);
+        return cc::make_hash(t.fmt, t.dim, t.usage, t.width, t.height, t.depth_or_array_size, t.num_mips, t.num_samples, t.optimized_clear_value);
     }
 
     constexpr size_t operator()(buffer_info const& b) const noexcept { return cc::make_hash(b.size_bytes, b.stride_bytes, b.allow_uav, b.heap); }

--- a/src/phantasm-renderer/common/state_info.hh
+++ b/src/phantasm-renderer/common/state_info.hh
@@ -36,7 +36,7 @@ struct shader_view_info
 struct graphics_pass_info_data
 {
     phi::pipeline_config graphics_config = {};
-    unsigned vertex_size_bytes = 0;
+    uint32_t vertex_size_bytes = 0;
     bool has_root_consts = false;
     phi::flat_vector<phi::vertex_attribute_info, 8> vertex_attributes;
     phi::flat_vector<phi::arg::shader_arg_shape, phi::limits::max_shader_arguments> arg_shapes;

--- a/src/phantasm-renderer/detail/auto_destroyer.cc
+++ b/src/phantasm-renderer/detail/auto_destroyer.cc
@@ -5,13 +5,11 @@
 #include <phantasm-renderer/Context.hh>
 
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::buffer& v) { ctx->free_to_cache(v); }
-void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::render_target& v) { ctx->free_to_cache(v); }
 void pr::detail::auto_destroy_proxy::cache_deref(pr::Context* ctx, const pr::texture& v) { ctx->free_to_cache(v); }
 
 bool pr::detail::auto_destroy_proxy::is_destroy_legal(pr::Context* ctx) { return ctx->is_shutting_down(); }
 
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::buffer& v) { ctx->free_untyped(v.res); }
-void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::render_target& v) { ctx->free_untyped(v.res); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::texture& v) { ctx->free_untyped(v.res); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pipeline_state_abstract& v) { ctx->freePipelineState(v._handle); }
 void pr::detail::auto_destroy_proxy::destroy(pr::Context* ctx, const pr::shader_binary& v) { ctx->free(v); }

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -12,13 +12,11 @@ namespace detail
 struct PR_API auto_destroy_proxy
 {
     static void cache_deref(pr::Context* ctx, buffer const& v);
-    static void cache_deref(pr::Context* ctx, render_target const& v);
     static void cache_deref(pr::Context* ctx, texture const& v);
 
     static bool is_destroy_legal(pr::Context* ctx);
 
     static void destroy(pr::Context* ctx, buffer const& v);
-    static void destroy(pr::Context* ctx, render_target const& v);
     static void destroy(pr::Context* ctx, texture const& v);
     static void destroy(pr::Context* ctx, pipeline_state_abstract const& v);
     static void destroy(pr::Context* ctx, shader_binary const& v);

--- a/src/phantasm-renderer/detail/auto_destroyer.hh
+++ b/src/phantasm-renderer/detail/auto_destroyer.hh
@@ -2,13 +2,14 @@
 
 #include <clean-core/assert.hh>
 
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/fwd.hh>
 
 namespace pr
 {
 namespace detail
 {
-struct auto_destroy_proxy
+struct PR_API auto_destroy_proxy
 {
     static void cache_deref(pr::Context* ctx, buffer const& v);
     static void cache_deref(pr::Context* ctx, render_target const& v);

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.hh
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.hh
@@ -17,11 +17,13 @@ struct deferred_destruction_queue
 {
     void free(pr::Context& ctx, phi::handle::shader_view sv);
     void free(pr::Context& ctx, phi::handle::resource res);
+    void free(pr::Context& ctx, phi::handle::pipeline_state pso);
     void free_range(pr::Context& ctx, cc::span<phi::handle::resource const> res_range);
+    void free_range(pr::Context& ctx, cc::span<phi::handle::shader_view const> res_range);
 
     unsigned free_all_pending(pr::Context& ctx);
 
-    void initialize(cc::allocator* alloc, unsigned num_reserved_svs = 128, unsigned num_reserved_res = 128);
+    void initialize(cc::allocator* alloc, unsigned num_reserved_svs = 128, unsigned num_reserved_res = 128, unsigned num_reserved_psos = 32);
     void destroy(pr::Context& ctx);
 
 private:
@@ -33,6 +35,8 @@ private:
 
     cc::alloc_vector<phi::handle::shader_view> pending_svs_old;
     cc::alloc_vector<phi::handle::shader_view> pending_svs_new;
+    cc::alloc_vector<phi::handle::pipeline_state> pending_psos_old;
+    cc::alloc_vector<phi::handle::pipeline_state> pending_psos_new;
     cc::alloc_vector<phi::handle::resource> pending_res_old;
     cc::alloc_vector<phi::handle::resource> pending_res_new;
 

--- a/src/phantasm-renderer/detail/deferred_destruction_queue.hh
+++ b/src/phantasm-renderer/detail/deferred_destruction_queue.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include <clean-core/alloc_vector.hh>
 
 #include <phantasm-hardware-interface/handles.hh>
@@ -10,6 +12,7 @@ namespace pr
 {
 /// persistent queue of (PHI) resources pending destruction
 /// keeps track of GPU epochs and automatically frees older resources when enqueueing
+/// synchronised
 struct deferred_destruction_queue
 {
     void free(pr::Context& ctx, phi::handle::shader_view sv);
@@ -22,6 +25,9 @@ struct deferred_destruction_queue
     void destroy(pr::Context& ctx);
 
 private:
+    unsigned _free_pending_unsynced(pr::Context& ctx);
+
+private:
     gpu_epoch_t gpu_epoch_old = 0;
     gpu_epoch_t gpu_epoch_new = 0;
 
@@ -29,5 +35,7 @@ private:
     cc::alloc_vector<phi::handle::shader_view> pending_svs_new;
     cc::alloc_vector<phi::handle::resource> pending_res_old;
     cc::alloc_vector<phi::handle::resource> pending_res_new;
+
+    std::mutex mutex;
 };
 }

--- a/src/phantasm-renderer/fwd.hh
+++ b/src/phantasm-renderer/fwd.hh
@@ -29,15 +29,12 @@ struct auto_destroyer;
 // resources
 struct raw_resource;
 struct buffer;
-struct render_target;
 struct texture;
 
 using auto_buffer = auto_destroyer<buffer, auto_mode::guard>;
-using auto_render_target = auto_destroyer<render_target, auto_mode::guard>;
 using auto_texture = auto_destroyer<texture, auto_mode::guard>;
 
 using cached_buffer = auto_destroyer<buffer, auto_mode::cache>;
-using cached_render_target = auto_destroyer<render_target, auto_mode::cache>;
 using cached_texture = auto_destroyer<texture, auto_mode::cache>;
 
 

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -26,6 +26,13 @@ public:
         return *this;
     }
 
+    /// Add a shader argument shape
+    graphics_pass_info& arg(phi::arg::shader_arg_shape const& arg_shape)
+    {
+        _storage.get().arg_shapes.push_back(arg_shape);
+        return *this;
+    }
+
     /// add a shader argument matching the shape of a given pr::argument
     graphics_pass_info& arg(argument const& argument, bool has_cbv = false)
     {
@@ -134,6 +141,13 @@ public:
         return *this;
     }
 
+    /// Add a shader argument shape
+    compute_pass_info& arg(phi::arg::shader_arg_shape const& arg_shape)
+    {
+        _storage.get().arg_shapes.push_back(arg_shape);
+        return *this;
+    }
+
     /// add a shader argument matching the shape of a given pr::argument
     compute_pass_info& arg(argument const& argument, bool has_cbv = false)
     {
@@ -155,12 +169,8 @@ public:
         return *this;
     }
 
-private:
-    friend class raii::Frame;
     [[nodiscard]] cc::hash_t get_hash() const { return _storage.get_xxhash(); }
 
-private:
-    friend class Context;
     hashable_storage<compute_pass_info_data> _storage;
     phi::arg::shader_binary _shader;
 };

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -7,6 +7,7 @@
 #include <phantasm-renderer/common/hashable_storage.hh>
 
 #include <phantasm-renderer/argument.hh>
+#include <phantasm-renderer/common/api.hh>
 #include <phantasm-renderer/common/state_info.hh>
 #include <phantasm-renderer/enums.hh>
 #include <phantasm-renderer/fwd.hh>
@@ -15,7 +16,7 @@
 
 namespace pr
 {
-struct graphics_pass_info
+struct PR_API graphics_pass_info
 {
 public:
     /// Add a shader argument specifiying the amount of elements
@@ -123,7 +124,7 @@ public:
     cc::capped_vector<phi::arg::graphics_shader, 5> _shaders;
 };
 
-struct compute_pass_info
+struct PR_API compute_pass_info
 {
 public:
     /// Add a shader argument specifiying the amount of elements
@@ -199,7 +200,7 @@ template <class... ShaderTs>
     return res;
 }
 
-struct framebuffer_info
+struct PR_API framebuffer_info
 {
 public:
     /// Add a render target based on format only

--- a/src/phantasm-renderer/pass_info.hh
+++ b/src/phantasm-renderer/pass_info.hh
@@ -47,7 +47,7 @@ public:
     }
 
     /// Set vertex size and attributes from data
-    graphics_pass_info& vertex(unsigned size_bytes, cc::span<phi::vertex_attribute_info const> attributes)
+    graphics_pass_info& vertex(uint32_t size_bytes, cc::span<phi::vertex_attribute_info const> attributes)
     {
         _storage.get().vertex_size_bytes = size_bytes;
 
@@ -135,7 +135,7 @@ struct PR_API compute_pass_info
 {
 public:
     /// Add a shader argument specifiying the amount of elements
-    compute_pass_info& arg(unsigned num_srvs, unsigned num_uavs = 0, unsigned num_samplers = 0, bool has_cbv = false)
+    compute_pass_info& arg(uint32_t num_srvs, uint32_t num_uavs = 0, uint32_t num_samplers = 0, bool has_cbv = false)
     {
         _storage.get().arg_shapes.push_back({num_srvs, num_uavs, num_samplers, has_cbv});
         return *this;

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -26,20 +26,14 @@ struct buffer
     buffer_info info;
 };
 
-struct render_target
-{
-    raw_resource res;
-    render_target_info info;
-
-    int samples() const { return info.num_samples; }
-    tg::isize2 size() const { return {info.width, info.height}; }
-    pr::format format() const { return info.format; }
-};
-
 struct texture
 {
     raw_resource res;
     texture_info info;
+
+    int samples() const { return info.num_samples; }
+    tg::isize2 size() const { return {info.width, info.height}; }
+    pr::format format() const { return info.fmt; }
 };
 
 //
@@ -94,7 +88,6 @@ struct swapchain
 
 // move-only, self-destructing versions
 using auto_buffer = auto_destroyer<buffer, auto_mode::guard>;
-using auto_render_target = auto_destroyer<render_target, auto_mode::guard>;
 using auto_texture = auto_destroyer<texture, auto_mode::guard>;
 
 using auto_shader_binary = auto_destroyer<shader_binary, auto_mode::destroy>; // this is a CPU-only type, allow auto destruction
@@ -106,7 +99,6 @@ using auto_swapchain = auto_destroyer<swapchain, auto_mode::guard>;
 
 // move-only, self-cachefreeing versions
 using cached_buffer = auto_destroyer<buffer, auto_mode::cache>;
-using cached_render_target = auto_destroyer<render_target, auto_mode::cache>;
 using cached_texture = auto_destroyer<texture, auto_mode::cache>;
 
 

--- a/src/phantasm-renderer/resource_types.hh
+++ b/src/phantasm-renderer/resource_types.hh
@@ -18,18 +18,27 @@ struct raw_resource
 {
     phi::handle::resource handle = phi::handle::null_resource;
     uint64_t guid = 0;
+
+    bool is_valid() const { return handle.is_valid(); }
+    void invalidate() { handle.invalidate(); }
 };
 
 struct buffer
 {
     raw_resource res;
     buffer_info info;
+
+    bool is_valid() const { return res.handle.is_valid(); }
+    void invalidate() { res.handle.invalidate(); }
 };
 
 struct texture
 {
     raw_resource res;
     texture_info info;
+
+    bool is_valid() const { return res.handle.is_valid(); }
+    void invalidate() { res.handle.invalidate(); }
 
     int samples() const { return info.num_samples; }
     tg::isize2 size() const { return {info.width, info.height}; }
@@ -75,7 +84,7 @@ struct query_range
 {
     phi::handle::query_range handle = phi::handle::null_query_range;
     pr::query_type type;
-    unsigned num;
+    uint32_t num;
 };
 
 struct swapchain
@@ -97,7 +106,7 @@ using auto_fence = auto_destroyer<fence, auto_mode::guard>;
 using auto_query_range = auto_destroyer<query_range, auto_mode::guard>;
 using auto_swapchain = auto_destroyer<swapchain, auto_mode::guard>;
 
-// move-only, self-cachefreeing versions
+// move-only, self-cache-freeing versions
 using cached_buffer = auto_destroyer<buffer, auto_mode::cache>;
 using cached_texture = auto_destroyer<texture, auto_mode::cache>;
 


### PR DESCRIPTION
- Add instancing support
    - new optional argument in all `GraphicsPass::draw` overloads
- Fix data races in `Context::deferred_free` overloads
- Fix `Frame::upload_texture_subresource` offsets, return bytes written
- Add `deferred_free` for PSOs
- Add DLL support
- Add option to compile shaders in `/Od` and with embedded PDB info for shader debugging
- Improve ergonomics of `Graphics` / `ComputePass::bind` overloads (no longer redirects)
- Fix resource view semantics for some constellations regarding mip slices and array ranges
- Add array index / mip slice options when adding render targets to framebuffers